### PR TITLE
CRD‑8 — Wave 3 (OBS‑12..15) — Finalização ORR/Release

### DIFF
--- a/ops/watchers/a110_observability.yaml
+++ b/ops/watchers/a110_observability.yaml
@@ -3,7 +3,7 @@ groups:
     rules:
       # W-OBS-001 — p95(swap)
       - alert: OBS_P95_Swap_TooHigh
-        expr: histogram_quantile(0.95, sum by (le) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
+        expr: histogram_quantile(0.95, sum by (le, env, service) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
         for: 10m
         labels:
           severity: warn
@@ -13,7 +13,7 @@ groups:
           description: "p95 da operação swap excedeu 60ms por 10m. Verificar regressões, GC e cardinalidade."
 
       - alert: OBS_P95_Swap_TooHigh_Crit
-        expr: histogram_quantile(0.95, sum by (le) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
+        expr: histogram_quantile(0.95, sum by (le, env, service) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
         for: 30m
         labels:
           severity: critical
@@ -24,7 +24,7 @@ groups:
 
       # W-OBS-002 — staleness (oracle)
       - alert: OBS_Oracle_Stale
-        expr: max by (source) (data_freshness_seconds{source="oracle"}) > 5
+        expr: max by (source, service, env) (data_freshness_seconds{source="oracle"}) > 5
         for: 5m
         labels:
           severity: warn
@@ -35,8 +35,7 @@ groups:
 
       # W-OBS-003 — CDC lag
       - alert: OBS_CDC_Lag_Warn
-        expr: max by (stream) (cdc_lag_seconds{service="trendmarket-amm"}) > 10
-        expr: max by (stream) (cdc_lag_seconds) > 10
+        expr: max by (stream, service, env) (cdc_lag_seconds{service="trendmarket-amm"}) > 10
         for: 10m
         labels:
           severity: warn
@@ -46,8 +45,7 @@ groups:
           description: "Lag de CDC acima de 10s por 10m."
 
       - alert: OBS_CDC_Lag_Crit
-        expr: max by (stream) (cdc_lag_seconds{service="trendmarket-amm"}) > 30
-        expr: max by (stream) (cdc_lag_seconds) > 30
+        expr: max by (stream, service, env) (cdc_lag_seconds{service="trendmarket-amm"}) > 30
         for: 5m
         labels:
           severity: critical
@@ -58,7 +56,7 @@ groups:
 
       # W-OBS-004 — drift (features críticas)
       - alert: OBS_Drift_Critical_Feature_Warn
-        expr: max by (feature) (drift_score{feature=~".*(price|volume|spread).*"}) > 0.2
+        expr: max by (feature, service, env) (drift_score{service="trendmarket-amm", feature=~".*(price|volume|spread).*"}) > 0.2
         for: 30m
         labels:
           severity: warn
@@ -68,7 +66,7 @@ groups:
           description: "PSI/KL acima de 0.2 por 30m. Verificar regime e baseline."
 
       - alert: OBS_Drift_Critical_Feature_Crit
-        expr: max by (feature) (drift_score{feature=~".*(price|volume|spread).*"}) > 0.4
+        expr: max by (feature, service, env) (drift_score{service="trendmarket-amm", feature=~".*(price|volume|spread).*"}) > 0.4
         for: 15m
         labels:
           severity: critical
@@ -80,7 +78,6 @@ groups:
       # W-OBS-005 — cobertura de hooks
       - alert: OBS_Hook_Coverage_Low
         expr: min by (env) (hook_coverage_ratio{env=~".+"}) < 0.95
-        expr: hook_coverage_ratio < 0.95
         for: 30m
         labels:
           severity: warn
@@ -91,7 +88,7 @@ groups:
 
       # W-OBS-006 — hooks sem execução
       - alert: OBS_Hook_Execution_Stalled
-        expr: sum by (hook_id) (increase(hook_executions_total{status="success"}[1h])) < 1
+        expr: sum by (hook_id, env) (increase(hook_executions_total{status="success"}[1h])) < 1
         for: 5m
         labels:
           severity: warn
@@ -124,7 +121,7 @@ groups:
 
       # W-OBS-009 — prober sintético degradado
       - alert: OBS_Synthetic_OK_Ratio_Low
-        expr: synthetic_ok_ratio < 0.99
+        expr: avg_over_time(synthetic_ok_ratio{service="trendmarket-amm"}[10m]) < 0.99
         for: 15m
         labels:
           severity: warn
@@ -132,131 +129,3 @@ groups:
         annotations:
           summary: "Synthetic OK ratio abaixo de 99%"
           description: "Prober sintético reportou sucesso <99% na janela."
-- name: a110_observability
-  rules:
-  # W‑OBS‑001 — p95(swap)
-  - alert: OBS_P95_Swap_TooHigh
-    expr: histogram_quantile(0.95, sum by (le) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
-    for: 10m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "p95(swap) acima do SLO (60ms)"
-      description: "p95 da operação swap excedeu 60ms por 10m. Verificar regressões, GC e cardinalidade."
-
-  - alert: OBS_P95_Swap_TooHigh_Crit
-    expr: histogram_quantile(0.95, sum by (le) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
-    for: 30m
-    labels:
-      severity: critical
-      team: ce
-    annotations:
-      summary: "p95(swap) crítico acima de 60ms"
-      description: "Persistência >30m. Ação imediata necessária."
-
-  # W‑OBS‑002 — staleness (oracle)
-  - alert: OBS_Oracle_Stale
-    expr: max by (source) (data_freshness_seconds{source="oracle"}) > 5
-    for: 5m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Freshness oracle > 5s"
-      description: "Dados de oracle acima do alvo de 5s na janela."
-
-  # W‑OBS‑003 — CDC lag
-  - alert: OBS_CDC_Lag_Warn
-    expr: max by (stream) (cdc_lag_seconds{env=~".+"}) > 10
-    for: 10m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "CDC lag > 10s (WARN)"
-      description: "Lag de CDC acima de 10s por 10m."
-
-  - alert: OBS_CDC_Lag_Crit
-    expr: max by (stream) (cdc_lag_seconds{env=~".+"}) > 30
-    for: 5m
-    labels:
-      severity: critical
-      team: ce
-    annotations:
-      summary: "CDC lag > 30s (CRIT)"
-      description: "Lag de CDC crítico por 5m."
-
-  # W‑OBS‑004 — drift (features críticas)
-  - alert: OBS_Drift_Critical_Feature_Warn
-    expr: max by (feature) (drift_score{feature=~".*(price|volume|spread).*"}) > 0.2
-    for: 30m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Drift (PSI/KL) > 0.2 em feature crítica"
-      description: "PSI/KL acima de 0.2 por 30m. Verificar regime e baseline."
-
-  - alert: OBS_Drift_Critical_Feature_Crit
-    expr: max by (feature) (drift_score{feature=~".*(price|volume|spread).*"}) > 0.4
-    for: 15m
-    labels:
-      severity: critical
-      team: ce
-    annotations:
-      summary: "Drift (PSI/KL) crítico > 0.4"
-      description: "PSI/KL acima de 0.4 por 15m em feature crítica. Acionar análise de distribuição."
-
-  # W‑OBS‑005 — hook coverage e execuções
-  - alert: OBS_Hook_Coverage_Low
-    expr: min by (env) (hook_coverage_ratio{env=~".+"}) < 0.95
-    for: 30m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Cobertura de hooks <95%"
-      description: "Cobertura de hooks caiu abaixo de 95% na janela de 30m. Checar hooks sem execução e falhas recentes."
-
-  - alert: OBS_Hook_Execution_Stalled
-    expr: sum by (hook_id) (increase(hook_executions_total{status="success"}[1h])) == 0
-    for: 1h
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Hook sem execuções em 1h"
-      description: "O hook {{ $labels.hook_id }} não executou na última hora. Validar cobertura A110 e jobs dependentes."
-
-  # W-OBS-006 — Cardinalidade e custos
-  - alert: OBS_Cardinality_Budget_Warn
-    expr: max by (metric) (observability_series_budget_ratio{metric=~".+"}) > 0.7
-    for: 15m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Cardinalidade acima de 70% do orçamento"
-      description: "A métrica {{ $labels.metric }} consumiu {{ humanizePercentage $value }} do budget de séries. Reduzir labels ou revisar agregações."
-
-  - alert: OBS_Cardinality_Budget_Crit
-    expr: max by (metric) (observability_series_budget_ratio{metric=~".+"}) > 0.9
-    for: 10m
-    labels:
-      severity: critical
-      team: ce
-    annotations:
-      summary: "Cardinalidade crítica acima de 90%"
-      description: "A métrica {{ $labels.metric }} ultrapassou 90% do budget de séries. Mitigar imediatamente antes do blow-up de custos."
-
-  # W-OBS-007 — Synthetic prober
-  - alert: OBS_Synthetic_OK_Ratio_Low
-    expr: avg_over_time(synthetic_ok_ratio{env=~".+"}[10m]) < 0.99
-    for: 10m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Synthetic prober com sucesso <99%"
-      description: "O ratio de sucesso do prober sintético caiu abaixo de 99% por 10m. Investigar regressões em /health ou rotas críticas."

--- a/ops/watchers/tests/a110_rules_test.yaml
+++ b/ops/watchers/tests/a110_rules_test.yaml
@@ -13,7 +13,7 @@ tests:
   - eval_time: 15m
     alertname: OBS_P95_Swap_TooHigh
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce' }
+    - exp_labels: { severity: 'warn', team: 'ce', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -25,7 +25,7 @@ tests:
   - eval_time: 10m
     alertname: OBS_Oracle_Stale
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce', source: 'oracle' }
+    - exp_labels: { severity: 'warn', team: 'ce', source: 'oracle', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -37,7 +37,7 @@ tests:
   - eval_time: 15m
     alertname: OBS_CDC_Lag_Warn
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce', stream: 'orders' }
+    - exp_labels: { severity: 'warn', team: 'ce', stream: 'orders', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -49,7 +49,7 @@ tests:
   - eval_time: 10m
     alertname: OBS_CDC_Lag_Crit
     exp_alerts:
-    - exp_labels: { severity: 'critical', team: 'ce', stream: 'orders' }
+    - exp_labels: { severity: 'critical', team: 'ce', stream: 'orders', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -61,7 +61,7 @@ tests:
   - eval_time: 50m
     alertname: OBS_Drift_Critical_Feature_Warn
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce', feature: 'price_psi' }
+    - exp_labels: { severity: 'warn', team: 'ce', feature: 'price_psi', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -73,7 +73,7 @@ tests:
   - eval_time: 25m
     alertname: OBS_Drift_Critical_Feature_Crit
     exp_alerts:
-    - exp_labels: { severity: 'critical', team: 'ce', feature: 'volume_psi' }
+    - exp_labels: { severity: 'critical', team: 'ce', feature: 'volume_psi', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -97,7 +97,7 @@ tests:
   - eval_time: 1h
     alertname: OBS_Hook_Execution_Stalled
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce', hook_id: 'hook_pre_trade' }
+    - exp_labels: { severity: 'warn', team: 'ce', hook_id: 'hook_pre_trade', env: 'dev' }
 
 
 - interval: 1m


### PR DESCRIPTION
Escopo
- CI/ORR T0..T8; watchers A110 + tests; dashboards D1..D6; linter de labels; SBOM/custos.
- Ajuste dos watchers A110 para preservar labels canônicas e limpeza de duplicações.
- Atualização do teste smoke do promtool para cobrir os labels esperados.
Arquivos tocados
- .github/workflows/**, scripts/**, ops/**, docs/obs/**
- Este PR altera especificamente ops/watchers/a110_observability.yaml e ops/watchers/tests/a110_rules_test.yaml.
Como validar (CI)
1) Actions → CRD Epic — Plan (default)
2) Actions → CRD Epic - Exec (profile=fast → depois full)
Aceite
- summary.json = {"acceptance":"OK","gatecheck":"OK"}
- Required verdes: plan/plan, exec/orr
Evidências
- links dos runs + artifact (obs-bundle-*) + **bundle.sha256.txt (conteúdo colado aqui)** — pendente de execução neste ambiente offline.
Riscos/Mitigação
- flapping (usar `for:`); cardinalidade (linter, budgets 70%)
Próximos passos
- Release com bundle + SHA256 e fechamento do épico

------
https://chatgpt.com/codex/tasks/task_e_68f2a78fb5f0833087e98a4e9bd3a184