### PR TITLE
CRD‑8 — Wave 3 (OBS‑12..15) — Finalização ORR/Release

### DIFF
--- a/ops/watchers/a110_observability.yaml
+++ b/ops/watchers/a110_observability.yaml
@@ -3,7 +3,7 @@ groups:
     rules:
       # W-OBS-001 — p95(swap)
       - alert: OBS_P95_Swap_TooHigh
-        expr: histogram_quantile(0.95, sum by (le) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
+        expr: histogram_quantile(0.95, sum by (le, env, service) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
         for: 10m
         labels:
           severity: warn
@@ -13,7 +13,7 @@ groups:
           description: "p95 da operação swap excedeu 60ms por 10m. Verificar regressões, GC e cardinalidade."
 
       - alert: OBS_P95_Swap_TooHigh_Crit
-        expr: histogram_quantile(0.95, sum by (le) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
+        expr: histogram_quantile(0.95, sum by (le, env, service) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
         for: 30m
         labels:
           severity: critical
@@ -24,7 +24,7 @@ groups:
 
       # W-OBS-002 — staleness (oracle)
       - alert: OBS_Oracle_Stale
-        expr: max by (source) (data_freshness_seconds{source="oracle"}) > 5
+        expr: max by (source, service, env) (data_freshness_seconds{source="oracle"}) > 5
         for: 5m
         labels:
           severity: warn
@@ -35,8 +35,7 @@ groups:
 
       # W-OBS-003 — CDC lag
       - alert: OBS_CDC_Lag_Warn
-        expr: max by (stream) (cdc_lag_seconds{service="trendmarket-amm"}) > 10
-        expr: max by (stream) (cdc_lag_seconds) > 10
+        expr: max by (stream, service, env) (cdc_lag_seconds{service="trendmarket-amm"}) > 10
         for: 10m
         labels:
           severity: warn
@@ -46,8 +45,7 @@ groups:
           description: "Lag de CDC acima de 10s por 10m."
 
       - alert: OBS_CDC_Lag_Crit
-        expr: max by (stream) (cdc_lag_seconds{service="trendmarket-amm"}) > 30
-        expr: max by (stream) (cdc_lag_seconds) > 30
+        expr: max by (stream, service, env) (cdc_lag_seconds{service="trendmarket-amm"}) > 30
         for: 5m
         labels:
           severity: critical
@@ -58,7 +56,7 @@ groups:
 
       # W-OBS-004 — drift (features críticas)
       - alert: OBS_Drift_Critical_Feature_Warn
-        expr: max by (feature) (drift_score{feature=~".*(price|volume|spread).*"}) > 0.2
+        expr: max by (feature, service, env) (drift_score{service="trendmarket-amm", feature=~".*(price|volume|spread).*"}) > 0.2
         for: 30m
         labels:
           severity: warn
@@ -68,7 +66,7 @@ groups:
           description: "PSI/KL acima de 0.2 por 30m. Verificar regime e baseline."
 
       - alert: OBS_Drift_Critical_Feature_Crit
-        expr: max by (feature) (drift_score{feature=~".*(price|volume|spread).*"}) > 0.4
+        expr: max by (feature, service, env) (drift_score{service="trendmarket-amm", feature=~".*(price|volume|spread).*"}) > 0.4
         for: 15m
         labels:
           severity: critical
@@ -80,7 +78,6 @@ groups:
       # W-OBS-005 — cobertura de hooks
       - alert: OBS_Hook_Coverage_Low
         expr: min by (env) (hook_coverage_ratio{env=~".+"}) < 0.95
-        expr: hook_coverage_ratio < 0.95
         for: 30m
         labels:
           severity: warn
@@ -91,7 +88,7 @@ groups:
 
       # W-OBS-006 — hooks sem execução
       - alert: OBS_Hook_Execution_Stalled
-        expr: sum by (hook_id) (increase(hook_executions_total{status="success"}[1h])) < 1
+        expr: sum by (hook_id, env) (increase(hook_executions_total{status="success"}[1h])) < 1
         for: 5m
         labels:
           severity: warn
@@ -124,7 +121,7 @@ groups:
 
       # W-OBS-009 — prober sintético degradado
       - alert: OBS_Synthetic_OK_Ratio_Low
-        expr: synthetic_ok_ratio < 0.99
+        expr: avg_over_time(synthetic_ok_ratio{service="trendmarket-amm"}[10m]) < 0.99
         for: 15m
         labels:
           severity: warn
@@ -132,131 +129,3 @@ groups:
         annotations:
           summary: "Synthetic OK ratio abaixo de 99%"
           description: "Prober sintético reportou sucesso <99% na janela."
-- name: a110_observability
-  rules:
-  # W‑OBS‑001 — p95(swap)
-  - alert: OBS_P95_Swap_TooHigh
-    expr: histogram_quantile(0.95, sum by (le) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
-    for: 10m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "p95(swap) acima do SLO (60ms)"
-      description: "p95 da operação swap excedeu 60ms por 10m. Verificar regressões, GC e cardinalidade."
-
-  - alert: OBS_P95_Swap_TooHigh_Crit
-    expr: histogram_quantile(0.95, sum by (le) (rate(amm_op_latency_seconds_bucket{op="swap"}[5m]))) > 0.06
-    for: 30m
-    labels:
-      severity: critical
-      team: ce
-    annotations:
-      summary: "p95(swap) crítico acima de 60ms"
-      description: "Persistência >30m. Ação imediata necessária."
-
-  # W‑OBS‑002 — staleness (oracle)
-  - alert: OBS_Oracle_Stale
-    expr: max by (source) (data_freshness_seconds{source="oracle"}) > 5
-    for: 5m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Freshness oracle > 5s"
-      description: "Dados de oracle acima do alvo de 5s na janela."
-
-  # W‑OBS‑003 — CDC lag
-  - alert: OBS_CDC_Lag_Warn
-    expr: max by (stream) (cdc_lag_seconds{env=~".+"}) > 10
-    for: 10m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "CDC lag > 10s (WARN)"
-      description: "Lag de CDC acima de 10s por 10m."
-
-  - alert: OBS_CDC_Lag_Crit
-    expr: max by (stream) (cdc_lag_seconds{env=~".+"}) > 30
-    for: 5m
-    labels:
-      severity: critical
-      team: ce
-    annotations:
-      summary: "CDC lag > 30s (CRIT)"
-      description: "Lag de CDC crítico por 5m."
-
-  # W‑OBS‑004 — drift (features críticas)
-  - alert: OBS_Drift_Critical_Feature_Warn
-    expr: max by (feature) (drift_score{feature=~".*(price|volume|spread).*"}) > 0.2
-    for: 30m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Drift (PSI/KL) > 0.2 em feature crítica"
-      description: "PSI/KL acima de 0.2 por 30m. Verificar regime e baseline."
-
-  - alert: OBS_Drift_Critical_Feature_Crit
-    expr: max by (feature) (drift_score{feature=~".*(price|volume|spread).*"}) > 0.4
-    for: 15m
-    labels:
-      severity: critical
-      team: ce
-    annotations:
-      summary: "Drift (PSI/KL) crítico > 0.4"
-      description: "PSI/KL acima de 0.4 por 15m em feature crítica. Acionar análise de distribuição."
-
-  # W‑OBS‑005 — hook coverage e execuções
-  - alert: OBS_Hook_Coverage_Low
-    expr: min by (env) (hook_coverage_ratio{env=~".+"}) < 0.95
-    for: 30m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Cobertura de hooks <95%"
-      description: "Cobertura de hooks caiu abaixo de 95% na janela de 30m. Checar hooks sem execução e falhas recentes."
-
-  - alert: OBS_Hook_Execution_Stalled
-    expr: sum by (hook_id) (increase(hook_executions_total{status="success"}[1h])) == 0
-    for: 1h
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Hook sem execuções em 1h"
-      description: "O hook {{ $labels.hook_id }} não executou na última hora. Validar cobertura A110 e jobs dependentes."
-
-  # W-OBS-006 — Cardinalidade e custos
-  - alert: OBS_Cardinality_Budget_Warn
-    expr: max by (metric) (observability_series_budget_ratio{metric=~".+"}) > 0.7
-    for: 15m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Cardinalidade acima de 70% do orçamento"
-      description: "A métrica {{ $labels.metric }} consumiu {{ humanizePercentage $value }} do budget de séries. Reduzir labels ou revisar agregações."
-
-  - alert: OBS_Cardinality_Budget_Crit
-    expr: max by (metric) (observability_series_budget_ratio{metric=~".+"}) > 0.9
-    for: 10m
-    labels:
-      severity: critical
-      team: ce
-    annotations:
-      summary: "Cardinalidade crítica acima de 90%"
-      description: "A métrica {{ $labels.metric }} ultrapassou 90% do budget de séries. Mitigar imediatamente antes do blow-up de custos."
-
-  # W-OBS-007 — Synthetic prober
-  - alert: OBS_Synthetic_OK_Ratio_Low
-    expr: avg_over_time(synthetic_ok_ratio{env=~".+"}[10m]) < 0.99
-    for: 10m
-    labels:
-      severity: warn
-      team: ce
-    annotations:
-      summary: "Synthetic prober com sucesso <99%"
-      description: "O ratio de sucesso do prober sintético caiu abaixo de 99% por 10m. Investigar regressões em /health ou rotas críticas."

--- a/ops/watchers/tests/a110_rules_test.yaml
+++ b/ops/watchers/tests/a110_rules_test.yaml
@@ -13,7 +13,7 @@ tests:
   - eval_time: 15m
     alertname: OBS_P95_Swap_TooHigh
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce' }
+    - exp_labels: { severity: 'warn', team: 'ce', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -25,7 +25,7 @@ tests:
   - eval_time: 10m
     alertname: OBS_Oracle_Stale
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce', source: 'oracle' }
+    - exp_labels: { severity: 'warn', team: 'ce', source: 'oracle', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -37,7 +37,7 @@ tests:
   - eval_time: 15m
     alertname: OBS_CDC_Lag_Warn
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce', stream: 'orders' }
+    - exp_labels: { severity: 'warn', team: 'ce', stream: 'orders', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -49,7 +49,7 @@ tests:
   - eval_time: 10m
     alertname: OBS_CDC_Lag_Crit
     exp_alerts:
-    - exp_labels: { severity: 'critical', team: 'ce', stream: 'orders' }
+    - exp_labels: { severity: 'critical', team: 'ce', stream: 'orders', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -61,7 +61,7 @@ tests:
   - eval_time: 50m
     alertname: OBS_Drift_Critical_Feature_Warn
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce', feature: 'price_psi' }
+    - exp_labels: { severity: 'warn', team: 'ce', feature: 'price_psi', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -73,7 +73,7 @@ tests:
   - eval_time: 25m
     alertname: OBS_Drift_Critical_Feature_Crit
     exp_alerts:
-    - exp_labels: { severity: 'critical', team: 'ce', feature: 'volume_psi' }
+    - exp_labels: { severity: 'critical', team: 'ce', feature: 'volume_psi', service: 'trendmarket-amm', env: 'dev' }
 
 
 - interval: 1m
@@ -97,7 +97,7 @@ tests:
   - eval_time: 1h
     alertname: OBS_Hook_Execution_Stalled
     exp_alerts:
-    - exp_labels: { severity: 'warn', team: 'ce', hook_id: 'hook_pre_trade' }
+    - exp_labels: { severity: 'warn', team: 'ce', hook_id: 'hook_pre_trade', env: 'dev' }
 
 
 - interval: 1m

--- a/scripts/obs_probe_synthetic.sh
+++ b/scripts/obs_probe_synthetic.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-EVI="out/obs_gatecheck/evidence"; mkdir -p "$EVI"
-URL="${CE_URL:-http://127.0.0.1:8888}"; N=${N:-10}
-OK=0; TOTAL=0
+
+EVI="out/obs_gatecheck/evidence"
+mkdir -p "$EVI"
+
+URL="${CE_URL:-http://127.0.0.1:8888}"
+N=${N:-10}
+
+OK=0
+TOTAL=0
 
 STARTED_SERVER=0
 SERVER_PID=""
@@ -45,6 +51,7 @@ PY
     sleep 0.2
   done
 fi
+
 probe() {
   local r="$1"
   if curl -fsS "$URL/$r" >/dev/null 2>&1; then
@@ -52,6 +59,7 @@ probe() {
   fi
   TOTAL=$((TOTAL+1))
 }
+
 for r in health swap; do
   i=0
   while [ $i -lt $N ]; do
@@ -63,8 +71,10 @@ done
 OUTPUT="$EVI/synthetic_probe.json"
 export URL OUTPUT OK TOTAL
 
-python3 - <<PY
-import json, os
+python3 - <<'PY'
+import json
+import os
+
 path = os.environ["OUTPUT"]
 ok = int(os.environ.get("OK", "0"))
 total = int(os.environ.get("TOTAL", "0"))
@@ -79,4 +89,5 @@ with open(path, "w", encoding="utf-8") as fh:
     json.dump(payload, fh, indent=2)
     fh.write("\n")
 PY
+
 echo PROBE_OK

--- a/scripts/obs_release_manifest.py
+++ b/scripts/obs_release_manifest.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
@@ -14,206 +13,18 @@ if str(SRC) not in sys.path:
 
 from amm_obs.release import ReleaseManifestError, write_release_manifest
 
-
 OUT = ROOT / "out" / "obs_gatecheck"
 
 
 def main() -> int:
     try:
-        write_release_manifest(OUT)
+        manifest_path = write_release_manifest(OUT)
     except FileNotFoundError as exc:
         sys.exit(str(exc))
     except ReleaseManifestError as exc:
         sys.exit(str(exc))
 
-import json
-import sys
-from pathlib import Path
-from typing import Any, Dict, Optional
-from typing import Optional
-
-
-ROOT = Path(__file__).resolve().parents[1]
-OUT = ROOT / "out" / "obs_gatecheck"
-EVIDENCE = OUT / "evidence"
-
-
-def _load_json(path: Path) -> Dict[str, Any]:
-    if not path.exists():
-        return {}
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise SystemExit(f"JSON inválido em {path}: {exc}") from exc
-def _load_json(path: Path) -> dict:
-    if not path.exists():
-        return {}
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _bundle_sha() -> Optional[str]:
-    sha_path = OUT / "bundle.sha256.txt"
-    if not sha_path.exists():
-        return None
-    content = sha_path.read_text(encoding="utf-8").strip()
-    if not content:
-        return None
-    return content.split()[0]
-
-
-def _bundle_metadata() -> Dict[str, Any]:
-    bundle_path = OUT / "bundle.zip"
-    metadata: Dict[str, Any] = {
-        "path": str(bundle_path),
-        "sha256": _bundle_sha(),
-    }
-    if bundle_path.exists():
-        metadata["size_bytes"] = bundle_path.stat().st_size
-    else:
-        metadata["size_bytes"] = None
-    return metadata
-
-
-def _optional_payload(filename: str) -> Optional[Dict[str, Any]]:
-    path = EVIDENCE / filename
-    if not path.exists():
-        return None
-    data = _load_json(path)
-    return data if data else {}
-
-
-def _sbom_sha() -> Optional[str]:
-    sha_file = EVIDENCE / "sbom.cdx.sha256"
-    if not sha_file.exists():
-        return None
-    content = sha_file.read_text(encoding="utf-8").strip()
-    if not content:
-        return None
-    return content.split()[0]
-
-
-def main() -> int:
-    summary_path = OUT / "summary.json"
-    if not summary_path.exists():
-        sys.exit("summary.json ausente; execute orr_all.sh antes do manifesto")
-    summary = _load_json(summary_path)
-    if summary.get("acceptance") != "OK" or summary.get("gatecheck") != "OK":
-        sys.exit("SUMMARY_FAIL")
-
-    checks = {
-        "metrics_unit": (EVIDENCE / "metrics_unit.json").exists(),
-        "prometheus_text": (EVIDENCE / "amm_metrics.prom").exists(),
-        "amm_state": (EVIDENCE / "amm_obs_state.json").exists(),
-        "metrics_summary": (EVIDENCE / "metrics_summary.json").exists(),
-        "trace_log_smoke": (EVIDENCE / "trace_log_smoke.json").exists(),
-        "pii_probe": (EVIDENCE / "pii_probe.json").exists(),
-        "synthetic_probe": (EVIDENCE / "synthetic_probe.json").exists(),
-        "chaos_summary": (EVIDENCE / "chaos_summary.json").exists(),
-        "costs_cardinality": (EVIDENCE / "costs_cardinality.json").exists(),
-        "sbom": (EVIDENCE / "sbom.cdx.json").exists(),
-        "baseline_perf": (EVIDENCE / "baseline_perf.json").exists(),
-        "golden_traces": (EVIDENCE / "golden_traces.json").exists(),
-    }
-
-    costs = _optional_payload("costs_cardinality.json") if checks["costs_cardinality"] else None
-    probe = _optional_payload("synthetic_probe.json") if checks["synthetic_probe"] else None
-    metrics_summary = _optional_payload("metrics_summary.json") if checks["metrics_summary"] else None
-    watchers = _optional_payload("watchers_simulation.json")
-    trace_smoke = _optional_payload("trace_log_smoke.json")
-    pii_probe = _optional_payload("pii_probe.json")
-    chaos_summary = _optional_payload("chaos_summary.json")
-    baseline = _optional_payload("baseline_perf.json")
-    golden_traces = _optional_payload("golden_traces.json")
-
-    manifest = {
-        "summary": summary,
-        "bundle": _bundle_metadata(),
-    costs = _load_json(EVIDENCE / "costs_cardinality.json") if checks["costs_cardinality"] else {}
-    probe = _load_json(EVIDENCE / "synthetic_probe.json") if checks["synthetic_probe"] else {}
-    metrics_summary = _load_json(EVIDENCE / "metrics_summary.json") if checks["metrics_summary"] else {}
-
-    manifest = {
-        "summary": summary,
-        "bundle": {
-            "path": str(OUT / "bundle.zip"),
-            "sha256": _bundle_sha(),
-        },
-        "evidence_checks": checks,
-        "costs": {
-            "total_estimated_usd_month": costs.get("total_estimated_usd_month"),
-            "max_ratio": costs.get("max_ratio"),
-            "max_metric": costs.get("max_ratio_metric"),
-        }
-        if costs is not None
-        if costs
-        else None,
-        "synthetic_probe": {
-            "ok": probe.get("ok"),
-            "total": probe.get("total"),
-            "ok_ratio": probe.get("ok_ratio"),
-        }
-        if probe is not None
-        if probe
-        else None,
-        "metrics": {
-            "p95_swap_seconds": metrics_summary.get("p95_swap_seconds"),
-            "synthetic_swap_ok_ratio": metrics_summary.get("synthetic_swap_ok_ratio"),
-        }
-        if metrics_summary is not None
-        else None,
-        "watchers": {
-            "simulated": bool(watchers.get("simulated")),
-            "alerts_expected": [
-                {
-                    "alert": item.get("alert"),
-                    "reason": item.get("reason"),
-                }
-                for item in watchers.get("alerts_expected", [])
-            ],
-            "alerts_count": len(watchers.get("alerts_expected", [])),
-        }
-        if watchers is not None
-        else None,
-        "drills": {
-            key: value
-            for key, value in {
-                "trace_log_smoke": {
-                    "total_spans": trace_smoke.get("total_spans"),
-                    "correlated_ratio": trace_smoke.get("correlated_ratio"),
-                    "observability_level": trace_smoke.get("observability_level"),
-                    "skipped": trace_smoke.get("skipped", False),
-                }
-                if trace_smoke is not None
-                else None,
-                "pii_probe": {
-                    "fields": sorted(pii_probe.keys()),
-                    "pii_fields": [
-                        field
-                        for field in pii_probe.keys()
-                        if field.lower() in {"cpf", "email", "name", "phone", "document"}
-                    ],
-                }
-                if pii_probe is not None
-                else None,
-                "chaos": chaos_summary if chaos_summary is not None else None,
-                "baseline_perf": baseline if baseline is not None else None,
-                "golden_traces": golden_traces if golden_traces is not None else None,
-            }.items()
-            if value is not None
-        },
-        "sbom": {
-            "path": str(EVIDENCE / "sbom.cdx.json"),
-            "sha256": _sbom_sha(),
-        }
-        if checks["sbom"]
-        if metrics_summary
-        else None,
-    }
-
-    OUT.mkdir(parents=True, exist_ok=True)
-    manifest_path = OUT / "release_manifest.json"
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-    print("RELEASE_MANIFEST_OK")
+    print(f"RELEASE_MANIFEST_OK {manifest_path}")
     return 0
 
 

--- a/scripts/obs_trace_log_smoke.py
+++ b/scripts/obs_trace_log_smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate correlation evidence between AMM spans and structured logs."""
+"""Trace/log correlation smoke test for the ORR bundle."""
 
 from __future__ import annotations
 
@@ -9,14 +9,9 @@ import sys
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
 
-
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_STATE_PATH = (
-    ROOT / "out" / "obs_gatecheck" / "evidence" / "amm_obs_state.json"
-)
-DEFAULT_OUTPUT_PATH = (
-    ROOT / "out" / "obs_gatecheck" / "evidence" / "trace_log_smoke.json"
-)
+DEFAULT_STATE_PATH = ROOT / "out" / "obs_gatecheck" / "evidence" / "amm_obs_state.json"
+DEFAULT_OUTPUT_PATH = ROOT / "out" / "obs_gatecheck" / "evidence" / "trace_log_smoke.json"
 
 
 def _build_log_index(entries: Iterable[Dict[str, object]]) -> Dict[Tuple[str, str], Dict[str, object]]:
@@ -118,63 +113,3 @@ def main(argv: Iterable[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-import json
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-STATE_PATH = ROOT / "out" / "obs_gatecheck" / "evidence" / "amm_obs_state.json"
-OUTPUT_PATH = ROOT / "out" / "obs_gatecheck" / "evidence" / "trace_log_smoke.json"
-
-if not STATE_PATH.exists():
-    sys.exit("amm_obs_state.json is missing; run T2 first")
-
-state = json.loads(STATE_PATH.read_text(encoding="utf-8"))
-level = state.get("meta", {}).get("observability_level", "full").lower()
-if level != "full":
-    payload = {
-        "total_spans": len(state.get("spans", [])),
-        "correlated_entries": [],
-        "correlated_ratio": None,
-        "observability_level": level,
-        "skipped": True,
-    }
-    OUTPUT_PATH.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    print("TRACE_LOG_SMOKE_OK")
-    sys.exit(0)
-
-spans = state.get("spans", [])
-logs = state.get("logs", [])
-log_index = {(entry["trace_id"], entry["span_id"]): entry for entry in logs}
-correlated = []
-for span in spans:
-    key = (span["trace_id"], span["span_id"])
-    log = log_index.get(key)
-    if log:
-        correlated.append(
-            {
-                "trace_id": span["trace_id"],
-                "span_id": span["span_id"],
-                "op": span["op"],
-                "latency_seconds": span["latency_seconds"],
-                "log_message": log["message"],
-                "log_level": log["level"],
-            }
-        )
-
-if not spans:
-    sys.exit("no spans captured for smoke test")
-
-if len(correlated) != len(spans):
-    sys.exit("TRACE_LOG_CORRELATION_FAIL")
-
-payload = {
-    "total_spans": len(spans),
-    "correlated_entries": correlated,
-    "correlated_ratio": 1.0,
-    "observability_level": "full",
-    "skipped": False,
-    "sample": correlated[0],
-}
-OUTPUT_PATH.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-print("TRACE_LOG_SMOKE_OK")

--- a/scripts/orr_t6_metrics_run.sh
+++ b/scripts/orr_t6_metrics_run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-EVI="out/obs_gatecheck/evidence"; mkdir -p "$EVI"
+
+EVI="out/obs_gatecheck/evidence"
+mkdir -p "$EVI"
+
 cat > "$EVI/watchers_simulation.json" <<'JSON'
 {
   "simulated": true,
@@ -12,8 +15,10 @@ cat > "$EVI/watchers_simulation.json" <<'JSON'
     {"alert": "OBS_Hook_Coverage_Low", "reason": "hook_coverage_ratio abaixo de 0.95"},
     {"alert": "OBS_Hook_Execution_Stalled", "reason": "hook_pre_trade sem execuções em 1h"},
     {"alert": "OBS_Cardinality_Budget_Warn", "reason": "observability_series_budget_ratio > 0.7"},
-    {"alert": "OBS_Cardinality_Budget_Crit", "reason": "observability_series_budget_ratio > 0.9"}
-    {"alert": "OBS_Hook_Execution_Stalled", "reason": "hook_pre_trade sem execuções em 1h"}
+    {"alert": "OBS_Cardinality_Budget_Crit", "reason": "observability_series_budget_ratio > 0.9"},
+    {"alert": "OBS_Synthetic_OK_Ratio_Low", "reason": "synthetic_ok_ratio abaixo de 99%"}
   ]
 }
 JSON
+
+printf 'T6_METRICS_OK\n'


### PR DESCRIPTION
Escopo
- CI/ORR T0..T8; watchers A110 + tests; dashboards D1..D6; linter de labels; SBOM/custos.
- Refino dos utilitários de release (manifest/metadata/notas) e do gerador determinístico de evidências.
- Ajustes nos scripts ORR (probe sintético, trace/log smoke, watchers sim) para fechar a entrega da wave.
Arquivos tocados
- .github/workflows/**, scripts/**, ops/**, docs/obs/**
Como validar (CI)
1) Actions → CRD Epic — Plan (default)
2) Actions → CRD Epic — Exec (profile=fast → depois full)
Aceite
- summary.json = {"acceptance":"OK","gatecheck":"OK"}
- Required verdes: plan/plan, exec/orr
Evidências
- links dos runs + artifact (obs-bundle-*) + bundle.sha256.txt — executar nos workflows após merge desta base.
Riscos/Mitigação
- flapping (usar `for:`); cardinalidade (linter, budgets 70%)
Próximos passos
- Release com bundle + SHA256 e fechamento do épico

------
https://chatgpt.com/codex/tasks/task_e_68f2a78fb5f0833087e98a4e9bd3a184