### PR TITLE
Fix cyclonedx invocation

### DIFF
--- a/docs/obs/CRD-8-epic.md
+++ b/docs/obs/CRD-8-epic.md
@@ -175,7 +175,7 @@ Script
 set -euo pipefail
 OUT="out/obs_gatecheck/evidence"; mkdir -p "$OUT"
 cargo install cargo-cyclonedx >/dev/null 2>&1 || true
-cargo cyclonedx generate --format json --output "$OUT/sbom.cdx.json"
+cargo cyclonedx --format json --output "$OUT/sbom.cdx.json"
 shasum -a 256 "$OUT/sbom.cdx.json" > "$OUT/sbom.cdx.sha256"
 echo SBOM_OK
 ```

--- a/scripts/obs_sbom.sh
+++ b/scripts/obs_sbom.sh
@@ -4,7 +4,7 @@ EVI="out/obs_gatecheck/evidence"; mkdir -p "$EVI"
 if command -v cargo >/dev/null 2>&1; then
   cargo install cargo-cyclonedx >/dev/null 2>&1 || true
   if cargo cyclonedx --help >/dev/null 2>&1; then
-    cargo cyclonedx generate --format json --output "$EVI/sbom.cdx.json"
+    cargo cyclonedx --format json --output "$EVI/sbom.cdx.json"
     if command -v sha256sum >/dev/null 2>&1; then sha256sum "$EVI/sbom.cdx.json" > "$EVI/sbom.cdx.sha256"; else shasum -a 256 "$EVI/sbom.cdx.json" > "$EVI/sbom.cdx.sha256"; fi
     echo SBOM_OK
   else


### PR DESCRIPTION
## Summary
- update the SBOM script to invoke `cargo cyclonedx` without the deprecated `generate` verb
- reflect the updated command in the CRD-8 epic runbook snippet so the documentation matches the script

## Testing
- `bash scripts/obs_sbom.sh`
- `bash scripts/orr_all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68f2dab442e483308cb9e989e1e137fa