### PR TITLE
Update SBOM capture to tee CycloneDX output

### DIFF
--- a/docs/obs/CRD-8-epic.md
+++ b/docs/obs/CRD-8-epic.md
@@ -175,8 +175,8 @@ Script
 set -euo pipefail
 OUT="out/obs_gatecheck/evidence"; mkdir -p "$OUT"
 cargo install cargo-cyclonedx >/dev/null 2>&1 || true
-cargo cyclonedx --format json --output "$OUT/sbom.cdx.json"
-shasum -a 256 "$OUT/sbom.cdx.json" > "$OUT/sbom.cdx.sha256"
+cargo cyclonedx --format json | tee "$OUT/sbom.cdx.json" >/dev/null
+if command -v sha256sum >/dev/null 2>&1; then sha256sum "$OUT/sbom.cdx.json" > "$OUT/sbom.cdx.sha256"; else shasum -a 256 "$OUT/sbom.cdx.json" > "$OUT/sbom.cdx.sha256"; fi
 echo SBOM_OK
 ```
 

--- a/scripts/obs_sbom.sh
+++ b/scripts/obs_sbom.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-EVI="out/obs_gatecheck/evidence"; mkdir -p "$EVI"
+OUT="out/obs_gatecheck/evidence"; mkdir -p "$OUT"
 if command -v cargo >/dev/null 2>&1; then
   cargo install cargo-cyclonedx >/dev/null 2>&1 || true
   if cargo cyclonedx --help >/dev/null 2>&1; then
-    cargo cyclonedx --format json --output "$EVI/sbom.cdx.json"
-    if command -v sha256sum >/dev/null 2>&1; then sha256sum "$EVI/sbom.cdx.json" > "$EVI/sbom.cdx.sha256"; else shasum -a 256 "$EVI/sbom.cdx.json" > "$EVI/sbom.cdx.sha256"; fi
+    cargo cyclonedx --format json | tee "$OUT/sbom.cdx.json" >/dev/null
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum "$OUT/sbom.cdx.json" > "$OUT/sbom.cdx.sha256"; else shasum -a 256 "$OUT/sbom.cdx.json" > "$OUT/sbom.cdx.sha256"; fi
     echo SBOM_OK
   else
     echo "cargo cyclonedx indisponível — SBOM skip"


### PR DESCRIPTION
## Summary
- update `scripts/obs_sbom.sh` to stream the CycloneDX JSON to disk via `tee` while preserving the hash generation and `SBOM_OK` marker
- mirror the revised SBOM snippet in `docs/obs/CRD-8-epic.md` so the runbook matches the script

## Testing
- bash scripts/orr_all.sh *(SBOM step skipped because `cargo cyclonedx` plugin cannot be fetched in this environment, pipeline still produced `ACCEPTANCE_OK`/`GATECHECK_OK`)*

------
https://chatgpt.com/codex/tasks/task_e_68f2dd8bcef883309e90bd876e12f1ea