### PR TITLE
Normalize Semgrep checksum comparison

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -98,9 +98,8 @@ jobs:
           curl -sSLO "${BASE}/semgrep-linux-amd64"
           curl -sSLo checksum.txt "${BASE}/semgrep-linux-amd64.sha256"
           # extrai um hash SHA-256 (64 hex) de qualquer linha do checksum
-          EXPECTED=$(grep -Eio '[[:xdigit:]]{64}' checksum.txt | head -n1)
-          EXPECTED=$(grep -Eio '[a-f0-9]{64}' checksum.txt | head -n1)
-          ACTUAL=$(sha256sum semgrep-linux-amd64 | awk '{print $1}')
+          EXPECTED=$(grep -Eio '[[:xdigit:]]{64}' checksum.txt | head -n1 | tr '[:upper:]' '[:lower:]')
+          ACTUAL=$(sha256sum semgrep-linux-amd64 | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
           if [ -z "$EXPECTED" ]; then
             echo "Não foi possível extrair SHA-256 do checksum da release"; exit 1
           fi


### PR DESCRIPTION
## Summary
- ensure the extracted Semgrep checksum is lowercased before comparison
- normalize the sha256sum output casing to avoid case-sensitive mismatches

## Testing
- not run (CI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f5110ac95083309bb326abd133680a