### PR TITLE
Improve Semgrep checksum fallback extraction

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -93,14 +93,39 @@ jobs:
         run: |
           set -euo pipefail
           VER=1.80.0
-          # Baixe preservando o nome esperado pelo arquivo .sha256
-          curl -sSLO "https://github.com/semgrep/semgrep/releases/download/v${VER}/semgrep-linux-amd64"
-          curl -sSLO "https://github.com/semgrep/semgrep/releases/download/v${VER}/semgrep-linux-amd64.sha256"
-          # Verifica: o .sha256 contém "<hash>  semgrep-linux-amd64"
-          sha256sum -c semgrep-linux-amd64.sha256
+          BASE="https://github.com/semgrep/semgrep/releases/download/v${VER}"
+          # baixa binário e checksum (independente do formato publicado)
+          curl -sSLO "${BASE}/semgrep-linux-amd64"
+          curl -sSLo checksum.txt "${BASE}/semgrep-linux-amd64.sha256"
+          # extrai um hash SHA-256 (64 hex) de qualquer linha do checksum
+          EXPECTED_RAW=$(grep -Eio '[[:xdigit:]]{64}' checksum.txt || true)
+          if [ -z "$EXPECTED_RAW" ]; then
+            EXPECTED_RAW=$(python - <<'PY' || true
+import re
+from pathlib import Path
+
+data = Path('checksum.txt').read_text(encoding='utf-8', errors='ignore')
+match = re.search(r'([0-9a-fA-F]{64})', data)
+if match:
+    print(match.group(1))
+else:
+    collapsed = ''.join(ch for ch in data if ch in '0123456789abcdefABCDEF')
+    if len(collapsed) >= 64:
+        print(collapsed[:64])
+PY
+)
+          fi
+          EXPECTED=$(printf '%s\n' "$EXPECTED_RAW" | head -n1 | tr '[:upper:]' '[:lower:]')
+          ACTUAL=$(sha256sum semgrep-linux-amd64 | awk '{print tolower($1)}')
+          if [ -z "$EXPECTED" ]; then
+            echo "Não foi possível extrair SHA-256 do checksum da release"; exit 1
+          fi
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "SHA256 mismatch: expected $EXPECTED got $ACTUAL"; exit 1
+          fi
           sudo install -m 0755 semgrep-linux-amd64 /usr/local/bin/semgrep
           semgrep --version
-          rm -f semgrep-linux-amd64 semgrep-linux-amd64.sha256
+          rm -f semgrep-linux-amd64 checksum.txt
 
       # -------- Node (se o repo usa scripts/front) --------
       - name: Setup Node


### PR DESCRIPTION
## Summary
- add a Python fallback to derive the Semgrep SHA-256 when the checksum file omits a plain 64-hex line
- retain lowercase normalization before comparing the expected and actual hashes

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f50a2f0bdc83309b6a9f1c0766ff0e