### PR TITLE
Update ORR workflow TLA handling

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -212,15 +212,59 @@ jobs:
           bash scripts/microbench_dec.sh
 
       # -------- TLA check (opcional) --------
+      - name: Locate TLA models
+        id: tla
+        run: |
+          set -euo pipefail
+          # Procura .tla em paths típicos e globalmente como fallback
+          # Prioriza docs/spec/tla para manter convenção do repo
+          TLA_GLOB=$(git ls-files 'docs/spec/tla/*.tla' || true)
+          if [ -z "$TLA_GLOB" ]; then
+            TLA_GLOB=$(git ls-files '*.tla' || true)
+          fi
+          if [ -n "$TLA_GLOB" ]; then
+            echo "have_tla=true" >> "$GITHUB_OUTPUT"
+            # seleciona o primeiro para check; matrix pode vir depois
+            SEL=$(printf "%s\n" "$TLA_GLOB" | head -n1)
+            echo "tla_file=$SEL" >> "$GITHUB_OUTPUT"
+            echo "[tla] found models:"
+            printf "  - %s\n" $TLA_GLOB
+            echo "[tla] selected: $SEL"
+          else
+            echo "have_tla=false" >> "$GITHUB_OUTPUT"
+            echo "[tla] no .tla files found; skipping TLA steps."
+          fi
+
+      - name: Apalache (pull + smoke)
+        if: ${{ inputs.run_tla && steps.tla.outputs.have_tla == 'true' }}
+        env:
+          APAL_IMG_PRIMARY: ghcr.io/apalache-mc/apalache:v0.50.3
+          APAL_IMG_FALLBACK: ghcr.io/apalache-mc/apalache:main
+        run: |
+          set -euo pipefail
+          # tenta versão pinada; se indisponível, fallback para :main
+          if ! docker pull "$APAL_IMG_PRIMARY" >/dev/null 2>&1; then
+            echo "[apalache] tag v0.50.3 indisponível; usando :main"
+            docker pull "$APAL_IMG_FALLBACK" >/dev/null
+            APAL_IMG="$APAL_IMG_FALLBACK"
+          else
+            APAL_IMG="$APAL_IMG_PRIMARY"
+          fi
+          docker run --rm "$APAL_IMG" apalache-mc version
+
       - name: TLA check (Apalache)
-        if: ${{ inputs.run_tla }}
+        if: ${{ inputs.run_tla && steps.tla.outputs.have_tla == 'true' }}
         run: |
           set -euo pipefail
           mkdir -p out/s4_orr
-          docker run --rm -v "$PWD/docs/spec/tla:/work" ghcr.io/informalsystems/apalache:0.46.2 check dec_pre_ga.tla | tee out/s4_orr/tla_report.txt
+          SEL="${{ steps.tla.outputs.tla_file }}"
+          # monta diretório do arquivo selecionado como /work e roda check
+          SEL_DIR=$(dirname "$SEL")
+          SEL_FILE=$(basename "$SEL")
+          docker run --rm -v "$PWD/$SEL_DIR:/work" "$APAL_IMG" apalache-mc check "$SEL_FILE" | tee out/s4_orr/tla_report.txt
 
       - name: Upload TLA report
-        if: ${{ inputs.run_tla }}
+        if: ${{ inputs.run_tla && steps.tla.outputs.have_tla == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: tla-report


### PR DESCRIPTION
## Summary
- detect the presence of `.tla` models before attempting to run Apalache in the ORR workflow
- pull a pinned Apalache image with fallback to `:main` and run the version smoke check
- run the TLA verification and upload the report only when both `run_tla` is true and models exist

## Testing
- not run (workflow-only change)

---

### Guia de Resolução de Conflitos (TLA)
- **Bloco "Apalache (pull + smoke)" e "TLA check (Apalache)"**: clique **Accept incoming changes**.
- **Passo antigo com `ghcr.io/informalsystems/apalache`**: clique **Accept incoming changes**.
- **Outros blocos (Semgrep, dbt, bundler etc.) não alterados por este PR**: em caso de dúvida, clique **Accept current changes**; se este PR também atualizar Semgrep para container/digest ou adicionar guards de dbt, escolha **Accept incoming changes** somente nesses trechos.


------
https://chatgpt.com/codex/tasks/task_e_68f55b2d58f483309d4a4cd0f2736a93