### PR TITLE
Fix TLA <> action syntax in dec_pre_ga module

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -3,6 +3,8 @@ EXTENDS Naturals, Sequences, TLC
 
 VARIABLES dec_p95, breach, rollback, recovered
 
+vars == <<dec_p95, breach, rollback, recovered>>
+
 Init ==
     /\ dec_p95 \in Nat
     /\ dec_p95 = 0
@@ -36,14 +38,15 @@ Stutter ==
 
 Next == MeasureBreached \/ RollbackIssued \/ RecoveredWithinBudget \/ Stutter
 
-Spec == Init /\ [][Next]_<<dec_p95, breach, rollback, recovered>>
+Spec == Init /\ [][Next]_vars
 
 Safety == [](breach => dec_p95 <= 1600)
 
-Liveness == WF_<<dec_p95, breach, rollback, recovered>>(RollbackIssued) /\
-            WF_<<dec_p95, breach, rollback, recovered>>(RecoveredWithinBudget)
+Liveness == WF_vars(RollbackIssued) /\
+            WF_vars(RecoveredWithinBudget)
 
 THEOREM Spec => Safety
-THEOREM Spec => <>RecoveredWithinBudget
+\* Corrigido: ação sob <> deve estar na forma <<A>>_vars (SANY)
+THEOREM Spec => <> <<RecoveredWithinBudget>>_vars
 
 ====


### PR DESCRIPTION
## Summary
- define the `vars` tuple for the `dec_pre_ga` specification so temporal operators share the same state vector
- wrap the `RecoveredWithinBudget` action under `<<A>>_vars` and reuse the tuple in temporal operators to satisfy SANY parsing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f56e594fb48330881232893c347a0b