### PR TITLE
docs(tla): normalizar anotacoes Snowcat em dec_pre_ga

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -1,7 +1,20 @@
 ---- MODULE dec_pre_ga ----
 EXTENDS Naturals, Sequences, TLC
 
-VARIABLES dec_p95, breach, rollback, recovered
+VARIABLES
+    \* @type: Int;
+    \* DEC p95 em milissegundos
+    dec_p95,
+    \* @type: Bool;
+    \* flag de violação da meta DEC
+    breach,
+    \* @type: Bool;
+    \* flag de rollback emitido
+    rollback,
+    \* @type: Bool;
+    \* sistema recuperado dentro do orçamento
+    recovered
+\* Corrigido: anotações Snowcat para variáveis de estado
 
 vars == <<dec_p95, breach, rollback, recovered>>
 


### PR DESCRIPTION
## Summary
- reposiciona as anotações @type das variáveis de estado em dec_pre_ga.tla para o formato aceito pelo Snowcat
- mantém os comentários de manutenção e de unidades em linhas separadas para evitar conflitos com o parser

## Testing
- docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/var/apalache" ghcr.io/informalsystems/apalache:0.50.3 apalache-mc typecheck dec_pre_ga.tla *(fails: `docker` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f5723b226083308333026d4395e29a