### PR TITLE
TLA: fix Snowcat annotations in dec_pre_ga

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -1,9 +1,25 @@
 ---- MODULE dec_pre_ga ----
 EXTENDS Naturals, Sequences, TLC
 
-VARIABLES dec_p95, breach, rollback, recovered
+VARIABLES
+    \* @type: Int; \* DEC p95 em milissegundos
+    dec_p95,
+    \* @type: Bool; \* flag de violação da meta DEC
+    breach,
+    \* @type: Bool; \* flag de rollback emitido
+    rollback,
+    \* @type: Bool; \* sistema recuperado dentro do orçamento
+    recovered
+\* Corrigido: anotações Snowcat para variáveis de estado
 
 vars == <<dec_p95, breach, rollback, recovered>>
+
+\* @type: Bool;
+TypeOK ==
+    /\ dec_p95 \in Nat
+    /\ breach \in BOOLEAN
+    /\ rollback \in BOOLEAN
+    /\ recovered \in BOOLEAN
 
 Init ==
     /\ dec_p95 \in Nat


### PR DESCRIPTION
## Summary
- align the Snowcat @type annotations in `dec_pre_ga.tla` to sit directly above each state variable
- introduce a `TypeOK` predicate documenting the expected domains for the state variables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5723b226083308333026d4395e29a