### PR TITLE
Ensure DEC Pre-GA TLA spec is ASCII-only and add guard to ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -258,6 +258,11 @@ jobs:
           fi
           set -e
 
+      - name: TLA ASCII guard
+        if: ${{ inputs.run_tla && steps.tla.outputs.have_tla == 'true' }}
+        run: |
+          bash scripts/tla_ascii_guard.sh
+
       - name: TLA check (Apalache)
         if: ${{ inputs.run_tla && steps.tla.outputs.have_tla == 'true' }}
         shell: bash

--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -1,80 +1,58 @@
 ---- MODULE dec_pre_ga ----
 EXTENDS Naturals, Sequences, TLC
 
-(**************************************************************************)
-(* Modelo DEC Pre-GA — revisado pela equipe (ASCII-only, Snowcat OK).      *)
-(* Melhorias:                                                               *)
-(* 1) Anotação Snowcat agregada ANTES de VARIABLES (1 bloco @type).         *)
-(* 2) Limite superior de dec_p95 quando breach=TRUE (<=1600) p/ Safety.     *)
-(* 3) UNCHANGED completo nas ações (sem variáveis não-especificadas).       *)
-(* 4) Remoção de ação Stutter (usamos [][Next]_vars).                        *)
-(**************************************************************************)
+\* @type: dec_p95: Int; breach: Bool; rollback: Bool; recovered: Bool;
 
-(* @type: dec_p95: Int; breach: Bool; rollback: Bool; recovered: Bool; *)
 VARIABLES dec_p95, breach, rollback, recovered
 
 vars == <<dec_p95, breach, rollback, recovered>>
 
-(**************************************************************************)
-(* Tipos e invariante estrutural                                           *)
-(**************************************************************************)
 TypeOK ==
-/\ dec_p95 \in Nat
-/\ breach \in BOOLEAN
-/\ rollback \in BOOLEAN
-/\ recovered \in BOOLEAN
+    /\ dec_p95 \in Nat
+    /\ breach \in BOOLEAN
+    /\ rollback \in BOOLEAN
+    /\ recovered \in BOOLEAN
 
-Inv == TypeOK /\ (breach => dec_p95 <= 1600)
-
-(**************************************************************************)
-(* Estado inicial                                                          *)
-(**************************************************************************)
 Init ==
-/\ TypeOK
-/\ dec_p95 = 0
-/\ breach = FALSE
-/\ rollback = FALSE
-/\ recovered = FALSE
+    /\ TypeOK
+    /\ dec_p95 = 0
+    /\ breach = FALSE
+    /\ rollback = FALSE
+    /\ recovered = FALSE
 
-(**************************************************************************)
-(* Ações                                                                   *)
-(**************************************************************************)
-* Medida viola a meta de DEC (p95 > 800ms, com teto de 1600ms sob breach)
+\* Medida viola a meta de DEC (p95 > 800ms; teto 1600ms sob degradacao)
 MeasureBreached ==
-/\ dec_p95' \in Nat
-/\ dec_p95' > 800
-/\ dec_p95' <= 1600
-/\ breach' = TRUE
-/\ UNCHANGED <<rollback, recovered>>
+    /\ dec_p95' \in Nat
+    /\ dec_p95' > 800
+    /\ dec_p95' <= 1600
+    /\ breach' = TRUE
+    /\ UNCHANGED <<rollback, recovered>>
 
-* Emite rollback quando há violação
+\* Emite rollback quando ha violacao
 RollbackIssued ==
-/\ breach = TRUE
-/\ rollback' = TRUE
-/\ UNCHANGED <<dec_p95, recovered, breach>>
+    /\ breach = TRUE
+    /\ rollback' = TRUE
+    /\ UNCHANGED <<dec_p95, recovered, breach>>
 
-* Sistema recupera dentro do orçamento (p95 <= 800ms)
+\* Sistema recupera dentro do orcamento (p95 <= 800ms)
 RecoveredWithinBudget ==
-/\ rollback = TRUE
-/\ dec_p95' \in Nat
-/\ dec_p95' <= 800
-/\ recovered' = TRUE
-/\ UNCHANGED <<breach, rollback>>
+    /\ rollback = TRUE
+    /\ dec_p95' \in Nat
+    /\ dec_p95' <= 800
+    /\ recovered' = TRUE
+    /\ UNCHANGED <<breach, rollback>>
 
-* Dinâmica (stuttering é dado por [][Next]_vars)
-Next == MeasureBreached / RollbackIssued / RecoveredWithinBudget
+\* Dinamica (stuttering implicito via [][])
+Next == MeasureBreached \/ RollbackIssued \/ RecoveredWithinBudget
 
-(**************************************************************************)
-(* Especificação, propriedades e teoremas                                  *)
-(**************************************************************************)
 Spec == Init /\ [][Next]_vars
 
+\* Seguranca: se ha breach, p95 fica limitado por 1600ms (degradacao controlada)
 Safety == [](breach => dec_p95 <= 1600)
 
-* Vivacidade: sob justiça fraca de rollback e recuperação
+\* Vivacidade sob justica fraca
 Liveness == WF_vars(RollbackIssued) /\ WF_vars(RecoveredWithinBudget)
 
-THEOREM Spec => []Inv
 THEOREM Spec => Safety
 THEOREM Spec => <> <<RecoveredWithinBudget>>_vars
 

--- a/scripts/tla_ascii_guard.sh
+++ b/scripts/tla_ascii_guard.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# 1) Bloqueia caracteres nao-ASCII nas specs
+if LC_ALL=C grep -n "[^[:ascii:]]" -r docs/spec/tla; then
+  echo "[tla-ascii-guard] Non-ASCII encontrado (use /\\, \\/ e \\*)" >&2
+  exit 1
+fi
+# 2) Garante que comentarios comecam com \\* (nunca com * no inicio de linha)
+if grep -n "^[[:space:]]\* " -r docs/spec/tla; then
+  echo "[tla-ascii-guard] Comentarios devem iniciar com \\\\* (backslash+asterisk)." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- replace docs/spec/tla/dec_pre_ga.tla with the provided ASCII-only version compatible with Apalache/Snowcat
- add a scripts/tla_ascii_guard.sh helper that fails when non-ASCII characters or malformed comments are found in TLA specs
- run the new guard in the _s4-orr workflow before the Apalache verification step

## Testing
- bash scripts/tla_ascii_guard.sh

------
https://chatgpt.com/codex/tasks/task_e_68f5a333fb208330b690686f42da1da1