### PR TITLE
Use glob pathspec to find dbt projects in ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -65,7 +65,7 @@ jobs:
           mkdir -p out
           # Procura controlada (git ls-files evita varrer cache/node_modules não versionados)
           DBT_PROJECTS=()
-          mapfile -t DBT_PROJECTS < <( git ls-files -z '**/dbt_project.yml' | xargs -0 -r -n1 dirname | sort -u )
+          mapfile -t DBT_PROJECTS < <( git ls-files -z ':(glob)**/dbt_project.yml' | xargs -0 -r -n1 dirname | sort -u )
           printf '%s\n' "${DBT_PROJECTS[@]}" > out/dbt_projects.txt
           if [ "${#DBT_PROJECTS[@]}" -gt 0 ]; then
             echo "have_dbt=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- update the dbt project discovery step to use git's glob pathspec magic for dbt_project.yml

## Testing
- `git ls-files -z ':(glob)**/dbt_project.yml' | xargs -0 -r -n1 dirname | sort -u`


------
https://chatgpt.com/codex/tasks/task_e_68f8646dedfc83308e0f9a2200e928af