### PR TITLE
Fix dbt project discovery glob in ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -65,7 +65,7 @@ jobs:
           mkdir -p out
           # Procura controlada (git ls-files evita varrer cache/node_modules não versionados)
           DBT_PROJECTS=()
-          mapfile -t DBT_PROJECTS < <( git ls-files -z ':(glob)**/dbt_project.yml' | xargs -0 -r -n1 dirname | sort -u )
+          mapfile -t DBT_PROJECTS < <( git ls-files -z -- ':(glob)**/dbt_project.yml' | xargs -0 -r -n1 dirname | sort -u )
           printf '%s\n' "${DBT_PROJECTS[@]}" > out/dbt_projects.txt
           if [ "${#DBT_PROJECTS[@]}" -gt 0 ]; then
             echo "have_dbt=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure the ORR workflow uses git's extended glob pattern when scanning for dbt projects

## Testing
- `git ls-files -z -- ':(glob)**/dbt_project.yml' | xargs -0 -n1`
- `bash -lc "set -euo pipefail; DBT_PROJECTS=(); mapfile -t DBT_PROJECTS < <( git ls-files -z -- ':(glob)**/dbt_project.yml' | xargs -0 -r -n1 dirname | sort -u ); printf '%s\n' \"have_dbt=\${#DBT_PROJECTS[@]}\"; printf '%s\n' \"first=\${DBT_PROJECTS[0]}\"; printf '%s\n' \"all=\${DBT_PROJECTS[*]}\""`

------
https://chatgpt.com/codex/tasks/task_e_68f8676331848330aed93d0c3d9d9c4f