### PR TITLE
Fix DBT project discovery glob in ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -65,7 +65,7 @@ jobs:
           mkdir -p out
           # Procura controlada (git ls-files evita varrer cache/node_modules não versionados)
           DBT_PROJECTS=()
-          mapfile -t DBT_PROJECTS < <( git ls-files -z -- ':(glob)**/dbt_project.yml' | xargs -0 -r -n1 dirname | sort -u )
+          mapfile -t DBT_PROJECTS < <( git ls-files -z ':(glob)**/dbt_project.yml' | xargs -0 -r -n1 dirname | sort -u )
           printf '%s\n' "${DBT_PROJECTS[@]}" > out/dbt_projects.txt
           if [ "${#DBT_PROJECTS[@]}" -gt 0 ]; then
             echo "have_dbt=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- update the DBT project discovery step to use Git's recursive glob pathspec so dbt_project.yml files are detected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f86d26c0488330a1925d75d4f36616