### PR TITLE
Restore S4 ORR workflow inputs

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -10,7 +10,21 @@ on:
         default: false
   workflow_call:
     inputs:
+      ref:
+        description: "Ref opcional para checkout"
+        required: false
+        type: string
       run_sut:
+        required: false
+        type: boolean
+        default: false
+      run_microbench:
+        description: "Executar microbench DEC"
+        required: false
+        type: boolean
+        default: false
+      run_tla:
+        description: "Executar checagens TLA"
         required: false
         type: boolean
         default: false
@@ -30,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Instalar Gitleaks (tarball)
         shell: bash


### PR DESCRIPTION
## Summary
- restore the reusable S4 ORR workflow inputs for `ref`, `run_microbench`, `run_tla`, and `run_sut`
- make the checkout step honor the provided `ref` when the workflow is reused

## Testing
- act workflow_dispatch -W .github/workflows/s4-exec.yml --dryrun *(fails: `act` not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f912e9c954833096f18a17a6035d92