### PR TITLE
Add GHCR login for Apalache workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -104,6 +104,14 @@ jobs:
             cat out/tla_models.txt
           } > out/tla_ascii_report.txt
 
+      - name: Login to GHCR for Apalache
+        if: ${{ ((github.event_name == 'workflow_call' && inputs.run_tla) || (github.event_name == 'workflow_dispatch' && fromJSON(github.event.inputs.run_tla || 'false'))) && steps.tla_scan.outputs.have_tla == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_APALACHE_TOKEN }}
+
       - name: Apalache (pull + smoke)
         if: ${{ ((github.event_name == 'workflow_call' && inputs.run_tla) || (github.event_name == 'workflow_dispatch' && fromJSON(github.event.inputs.run_tla || 'false'))) && steps.tla_scan.outputs.have_tla == 'true' }}
         shell: bash


### PR DESCRIPTION
## Summary
- add an authentication step using docker/login-action before the Apalache smoke test
- ensure the workflow pulls from ghcr.io with a dedicated GHCR_APALACHE_TOKEN secret

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f91da2b6cc833080e9d1ae57ff640e