### PR TITLE
Fix ORR workflow Apalache image path

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -120,13 +120,13 @@ jobs:
           mkdir -p out
           REPORT="out/tla_apalache_smoke.txt"
           : > "$REPORT"
-          docker pull ghcr.io/informal-systems/apalache:latest
+          docker pull ghcr.io/informalsystems/apalache:latest
           while IFS= read -r tla_file; do
             [ -z "$tla_file" ] && continue
             echo "[apalache] Checando ${tla_file}" | tee -a "$REPORT"
             docker run --rm \
               -v "$PWD":/workspace \
-              ghcr.io/informal-systems/apalache:latest \
+              ghcr.io/informalsystems/apalache:latest \
               check --init=Init --next=Next --inv=Safety "/workspace/${tla_file}" | tee -a "$REPORT"
           done < out/tla_models.txt
 


### PR DESCRIPTION
## Summary
- point the ORR Apalache smoke test step at the correct ghcr.io/informalsystems/apalache image

## Testing
- docker pull ghcr.io/informalsystems/apalache:latest *(fails: docker not available in CI test container)*

------
https://chatgpt.com/codex/tasks/task_e_68f9788b2dc08330b876f99802b73556