### PR TITLE
Fix Apalache workflow mount path

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -125,9 +125,10 @@ jobs:
             [ -z "$tla_file" ] && continue
             echo "[apalache] Checando ${tla_file}" | tee -a "$REPORT"
             docker run --rm \
-              -v "$PWD":/workspace \
+              -v "$PWD":/var/apalache \
+              --workdir /var/apalache \
               ghcr.io/informalsystems/apalache:latest \
-              check --init=Init --next=Next --inv=Safety "/workspace/${tla_file}" | tee -a "$REPORT"
+              check --init=Init --next=Next --inv=Safety "/var/apalache/${tla_file}" | tee -a "$REPORT"
           done < out/tla_models.txt
 
       - name: Upload ASCII report do TLA


### PR DESCRIPTION
## Summary
- mount the repository at /var/apalache for the Apalache smoke-check container
- run the TLA check command against the mounted path to keep model resolution working

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f97a86ab60833090cbd38b27942b7f