### PR TITLE
Update Apalache smoke check working directory

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -120,14 +120,15 @@ jobs:
           mkdir -p out
           REPORT="out/tla_apalache_smoke.txt"
           : > "$REPORT"
-          docker pull ghcr.io/informal-systems/apalache:latest
+          docker pull ghcr.io/informalsystems/apalache:latest
           while IFS= read -r tla_file; do
             [ -z "$tla_file" ] && continue
             echo "[apalache] Checando ${tla_file}" | tee -a "$REPORT"
             docker run --rm \
-              -v "$PWD":/workspace \
-              ghcr.io/informal-systems/apalache:latest \
-              check --init=Init --next=Next --inv=Safety "/workspace/${tla_file}" | tee -a "$REPORT"
+              -v "$PWD":/var/apalache \
+              -w /var/apalache \
+              ghcr.io/informalsystems/apalache:latest \
+              check --init=Init --next=Next --inv=Safety "/var/apalache/${tla_file}" | tee -a "$REPORT"
           done < out/tla_models.txt
 
       - name: Upload ASCII report do TLA


### PR DESCRIPTION
## Summary
- mount the repository into `/var/apalache` and run Apalache from that directory so the smoke check can create its output

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68f9788b2dc08330b876f99802b73556