### PR TITLE
Ensure Apalache workflow runs container with write permissions

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -125,6 +125,7 @@ jobs:
             [ -z "$tla_file" ] && continue
             echo "[apalache] Checando ${tla_file}" | tee -a "$REPORT"
             docker run --rm \
+              --user "$(id -u):$(id -g)" \
               -v "$PWD":/var/apalache \
               -w /var/apalache \
               --workdir /var/apalache \


### PR DESCRIPTION
## Summary
- run the Apalache docker container as the invoking user so it can write to /var/apalache

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f97e2d8c40833099fa6ea7ba04f0dd