### PR TITLE
Adjust Apalache Docker invocation for ORR

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -125,7 +125,8 @@ jobs:
             [ -z "$tla_file" ] && continue
             echo "[apalache] Checando ${tla_file}" | tee -a "$REPORT"
             docker run --rm \
-              --user "$(id -u):$(id -g)" \
+              -e LOCAL_UID="$(id -u)" \
+              -e LOCAL_GID="$(id -g)" \
               -v "$PWD":/var/apalache \
               -w /var/apalache \
               --workdir /var/apalache \


### PR DESCRIPTION
## Summary
- set LOCAL_UID and LOCAL_GID environment variables for the Apalache smoke check
- rely on the image entrypoint user setup instead of forcing a docker --user override

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68f980ed9a6c8330967264c773bf8b46