### PR TITLE
Update Apalache smoke step permissions

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -120,11 +120,14 @@ jobs:
           mkdir -p out
           REPORT="out/tla_apalache_smoke.txt"
           : > "$REPORT"
+          mkdir -p _apalache-out
+          chmod 775 _apalache-out
           docker pull ghcr.io/informalsystems/apalache:latest
           while IFS= read -r tla_file; do
             [ -z "$tla_file" ] && continue
             echo "[apalache] Checando ${tla_file}" | tee -a "$REPORT"
             docker run --rm \
+              --user "$(id -u):$(id -g)" \
               -e LOCAL_UID="$(id -u)" \
               -e LOCAL_GID="$(id -g)" \
               -v "$PWD":/var/apalache \


### PR DESCRIPTION
## Summary
- ensure the Apalache smoke check prepares the `_apalache-out` directory before running
- run the Apalache container with the GitHub runner UID/GID so generated files are writable

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f984064cd48330b58660207081f09e