### PR TITLE
Add Apalache report upload artifact to ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -166,6 +166,14 @@ jobs:
             out/tla_apalache_smoke.txt
           if-no-files-found: warn
 
+      - name: Upload relatório TLA (Apalache)
+        uses: actions/upload-artifact@v4
+        if: ${{ always() && inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' }}
+        with:
+          name: tla-report
+          path: out/s4_orr/tla_report.txt
+          if-no-files-found: ignore
+
       - name: Localizar projetos DBT
         id: dbt_scan
         shell: bash


### PR DESCRIPTION
## Summary
- add an additional upload step for the TLA Apalache report in the ORR workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f991f5dd54833084dc9a126d61a939