### PR TITLE
Add security inputs to _s4-orr workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -22,6 +22,16 @@ on:
         required: false
         type: boolean
         default: false
+      run_security:
+        description: Enable security scanning gate
+        required: false
+        type: boolean
+        default: false
+      security_fail_on_findings:
+        description: Fail workflow when security findings are detected
+        required: false
+        type: boolean
+        default: false
     secrets:
       GCP_SA_JSON:
         required: false


### PR DESCRIPTION
## Summary
- add optional `run_security` and `security_fail_on_findings` boolean inputs to the `_s4-orr` reusable workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fab72b5b288330bbf0ae34840eff91