### PR TITLE
Add security dispatch inputs to S4 ORR workflow

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -18,6 +18,16 @@ on:
         required: false
         type: boolean
         default: false
+      run_security:
+        description: "Executar varreduras de segurança"
+        required: false
+        type: boolean
+        default: false
+      security_fail_on_findings:
+        description: "Falhar se houver findings de segurança"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   call-orr:
@@ -27,4 +37,6 @@ jobs:
       ref: ${{ github.event.inputs.ref }}
       run_microbench: ${{ fromJSON(github.event.inputs.run_microbench || 'false') }}
       run_tla: ${{ fromJSON(github.event.inputs.run_tla || 'false') }}
+      run_security: ${{ fromJSON(github.event.inputs.run_security || 'false') }}
+      security_fail_on_findings: ${{ fromJSON(github.event.inputs.security_fail_on_findings || 'false') }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- add workflow_dispatch inputs to toggle security checks and failure behavior
- pass the new inputs through to the reusable S4 ORR workflow with fromJSON casting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fab72ea00c833093eb289ce9fd0f73