### PR TITLE
Fix Apalache workspace permissions

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -262,7 +262,8 @@ jobs:
           WORK="out/s4_orr/apalache_work"
           REPORT="out/s4_orr/tla_report.txt"
           rm -rf "$WORK"
-          mkdir -p "$WORK"
+          mkdir -p "$WORK/tmp"
+          chmod 1777 "$WORK" "$WORK/tmp"
           : > "$REPORT"
 
           APAL_IMG="${APAL_IMG:-ghcr.io/apalache-mc/apalache:v0.50.3}"


### PR DESCRIPTION
## Summary
- ensure the ORR workflow pre-creates the Apalache workspace and grants permissive access

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68face52f55883308aee202a8eb74728