### PR TITLE
Fix Apalache command invocation in ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -262,7 +262,8 @@ jobs:
           WORK="out/s4_orr/apalache_work"
           REPORT="out/s4_orr/tla_report.txt"
           rm -rf "$WORK"
-          mkdir -p "$WORK"
+          mkdir -p "$WORK/tmp"
+          chmod 1777 "$WORK" "$WORK/tmp"
           : > "$REPORT"
 
           APAL_IMG="${APAL_IMG:-ghcr.io/apalache-mc/apalache:v0.50.3}"
@@ -308,7 +309,7 @@ jobs:
             -v "${MOUNT_PATH}:/var/apalache" \
             -w /var/apalache \
             "$APAL_IMG" \
-            apalache-mc check "$MODULE" | tee -a "$REPORT"
+            check "$MODULE" | tee -a "$REPORT"
           RC=${PIPESTATUS[0]}
           set -e
 


### PR DESCRIPTION
## Summary
- invoke the Apalache container without repeating the apalache-mc command to respect its entrypoint

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68face52f55883308aee202a8eb74728