### PR TITLE
Fix Apalache entrypoint duplication in ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -262,7 +262,8 @@ jobs:
           WORK="out/s4_orr/apalache_work"
           REPORT="out/s4_orr/tla_report.txt"
           rm -rf "$WORK"
-          mkdir -p "$WORK"
+          mkdir -p "$WORK/tmp"
+          chmod 1777 "$WORK" "$WORK/tmp"
           : > "$REPORT"
 
           APAL_IMG="${APAL_IMG:-ghcr.io/apalache-mc/apalache:v0.50.3}"
@@ -307,6 +308,7 @@ jobs:
           docker run --rm \
             -v "${MOUNT_PATH}:/var/apalache" \
             -w /var/apalache \
+            --entrypoint "" \
             "$APAL_IMG" \
             apalache-mc check "$MODULE" | tee -a "$REPORT"
           RC=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- clear the Apalache container entrypoint before running the CLI to avoid duplicate apalache-mc arguments
- invoke apalache-mc explicitly so the workflow uses the intended command structure

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68face52f55883308aee202a8eb74728