### PR TITLE
Fix Apalache CLI invocation entrypoint

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -262,7 +262,8 @@ jobs:
           WORK="out/s4_orr/apalache_work"
           REPORT="out/s4_orr/tla_report.txt"
           rm -rf "$WORK"
-          mkdir -p "$WORK"
+          mkdir -p "$WORK/tmp"
+          chmod 1777 "$WORK" "$WORK/tmp"
           : > "$REPORT"
 
           APAL_IMG="${APAL_IMG:-ghcr.io/apalache-mc/apalache:v0.50.3}"
@@ -305,6 +306,7 @@ jobs:
 
           set +e
           docker run --rm \
+            --entrypoint "" \
             -v "${MOUNT_PATH}:/var/apalache" \
             -w /var/apalache \
             "$APAL_IMG" \


### PR DESCRIPTION
## Summary
- ensure the Apalache container runs with an empty entrypoint override so the command is not duplicated
- invoke `apalache-mc check` once the entrypoint is cleared

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68face52f55883308aee202a8eb74728