### PR TITLE
Fix Apalache docker invocation

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -306,10 +306,8 @@ jobs:
 
           set +e
           docker run --rm \
-            --entrypoint "" \
             -v "${MOUNT_PATH}:/var/apalache" \
             -w /var/apalache \
-            --entrypoint "" \
             "$APAL_IMG" \
             check "$MODULE" | tee -a "$REPORT"
           RC=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- stop overriding the Apalache container entrypoint so the default apalache-mc command is used
- invoke the container with only the desired `check "$MODULE"` arguments when running the TLA verification step

## Testing
- not run (requires GitHub ORR workflow)


------
https://chatgpt.com/codex/tasks/task_e_68fade051e44833083b5e96121c879b2