### PR TITLE
Fix Apalache annotations in dec_pre_ga

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -3,13 +3,13 @@ EXTENDS Naturals, TLC
 
 VARIABLES
   dec_p95,
-\* @type: Int
+\* @type: Int;
   breach,
-\* @type: Bool
+\* @type: Bool;
   rollback,
-\* @type: Bool
+\* @type: Bool;
   recovered
-\* @type: Bool
+\* @type: Bool;
 
 Init == TRUE
 


### PR DESCRIPTION
## Summary
- add the missing semicolon terminators to the type annotations in dec_pre_ga.tla so Apalache can parse them

## Testing
- docker --version (fails: command not found in container)


------
https://chatgpt.com/codex/tasks/task_e_68fadfdc5fb88330a83910115abafc30