### PR TITLE
Fix TLA variable type comment placement

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -2,14 +2,14 @@
 EXTENDS Naturals, TLC
 
 VARIABLES
-  dec_p95,
 \* @type: Int;
+  dec_p95,
+\* @type: Bool;
   breach,
 \* @type: Bool;
   rollback,
 \* @type: Bool;
   recovered
-\* @type: Bool;
 
 Init == TRUE
 


### PR DESCRIPTION
## Summary
- move each `@type` annotation in `dec_pre_ga.tla` directly above its variable
- ensure every annotation ends with a semicolon while keeping the variable list syntax valid

## Testing
- `bash -lc '...docker run --rm -v "${MOUNT_PATH}:/var/apalache" -w /var/apalache "$APAL_IMG" check "$MODULE"'` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fae28623548330a03ac42670556705