### PR TITLE
Fix dec_pre_ga TLA spec integer extends

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -1,5 +1,5 @@
 ---- MODULE dec_pre_ga ----
-EXTENDS Naturals, TLC
+EXTENDS Integers, Naturals, TLC
 
 VARIABLES
 \* @type: Int;


### PR DESCRIPTION
## Summary
- include the Integers module in the dec_pre_ga TLA specification so the Int annotation is defined

## Testing
- docker run --rm ghcr.io/apalache-mc/apalache:v0.50.3 version *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68faee1a14c4833088b99c75d1e0cd3e