### PR TITLE
docs: expose Int set for dec_pre_ga spec

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -1,5 +1,6 @@
 ---- MODULE dec_pre_ga ----
 EXTENDS Integers, Naturals, TLC
+\* Integers provides the Int set required by the Apalache checker.
 
 VARIABLES
 \* @type: Int;


### PR DESCRIPTION
## Summary
- ensure the dec_pre_ga TLA+ spec documents the Integers extension so the Int set is available to Apalache

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68faf33790b08330b45454c5c8577c53