### PR TITLE
Clarify dec_pre_ga TLA+ spec initialization

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -15,6 +15,7 @@ Threshold == 800
 
 Init ==
   /\ dec_p95 = 0
+  /\ dec_p95 \in Nat
   /\ breach = FALSE
   /\ rollback = FALSE
   /\ recovered = FALSE
@@ -22,9 +23,9 @@ Init ==
 Next ==
   \E new_p95 \in Nat:
     /\ dec_p95' = new_p95
-    /\ breach' = new_p95 > Threshold
+    /\ breach' = (new_p95 > Threshold)
     /\ rollback' = IF breach' THEN TRUE ELSE rollback
-    /\ recovered' = IF rollback /\ new_p95 <= Threshold THEN TRUE ELSE recovered
+    /\ recovered' = IF rollback /\ (new_p95 <= Threshold) THEN TRUE ELSE recovered
 
 Spec == Init /\ [][Next]_<<dec_p95, breach, rollback, recovered>>
 


### PR DESCRIPTION
## Summary
- add an explicit natural-number constraint to the initial value of `dec_p95`
- parenthesize boolean comparisons in `Next` to avoid Apalache precedence issues

## Testing
- ⚠️ `apalache-mc check --init=Init --next=Next docs/spec/tla/dec_pre_ga.tla` *(fails: command not found)*
- ⚠️ `docker run --rm -v "$(pwd)":/workspace -w /workspace apalache/mc:latest check --init=Init --next=Next docs/spec/tla/dec_pre_ga.tla` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68faf338e35c83308fc4c8446a250edc