### PR TITLE
Fix TLA+ type annotation formatting in dec_pre_ga spec

### DIFF
--- a/docs/spec/tla/dec_pre_ga.tla
+++ b/docs/spec/tla/dec_pre_ga.tla
@@ -2,13 +2,13 @@
 EXTENDS Integers, Naturals, TLC
 
 VARIABLES
-\* @type: Int;
+  \* @type: Int;
   dec_p95,
-\* @type: Bool;
+  \* @type: Bool;
   breach,
-\* @type: Bool;
+  \* @type: Bool;
   rollback,
-\* @type: Bool;
+  \* @type: Bool;
   recovered
 
 Threshold == 800


### PR DESCRIPTION
## Summary
- ensure the Apalache type annotations under the dec_pre_ga variable list include the trailing semicolon
- align the annotation comments with the variable indentation for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68faf33553508330981aa8874376b744