### PR TITLE
Fix bq_enable forwarding in S4 ORR Exec workflow

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -32,5 +32,5 @@ jobs:
       ref: ${{ inputs.ref }}
       run_microbench: ${{ inputs.run_microbench }}
       run_tla: ${{ inputs.run_tla }}
-      bq_enable: ${{ fromJSON(github.event.inputs.bq_enable || 'false') }}
+      bq_enable: ${{ inputs.bq_enable }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- forward the `bq_enable` input directly to the reusable S4 ORR workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68fbca5d6510833095f46ce186aa537c