### PR TITLE
Fix boolean parsing for bq_enable workflow input

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -32,5 +32,5 @@ jobs:
       ref: ${{ inputs.ref }}
       run_microbench: ${{ inputs.run_microbench }}
       run_tla: ${{ inputs.run_tla }}
-      bq_enable: ${{ inputs.bq_enable }}
+      bq_enable: ${{ fromJSON(inputs.bq_enable || 'false') }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- ensure the bq_enable input passed to the reusable workflow is parsed as a boolean using fromJSON

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbcc648a68833091920aea2490f762