### PR TITLE
Adjust bq_enable workflow input handling

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -32,5 +32,5 @@ jobs:
       ref: ${{ inputs.ref }}
       run_microbench: ${{ inputs.run_microbench }}
       run_tla: ${{ inputs.run_tla }}
-      bq_enable: ${{ fromJSON(inputs.bq_enable || 'false') }}
+      bq_enable: ${{ fromJSON(coalesce(inputs.bq_enable, 'false')) }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- ensure the S4 ORR Exec workflow reads the bq_enable flag from the dispatch inputs with a default of false via `coalesce`

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fbce482c6c8330bb9e1649bfd53d8a