### PR TITLE
Fix boolean input parsing in s4 exec workflow

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -32,5 +32,5 @@ jobs:
       ref: ${{ inputs.ref }}
       run_microbench: ${{ inputs.run_microbench }}
       run_tla: ${{ inputs.run_tla }}
-      bq_enable: ${{ fromJSON(coalesce(inputs.bq_enable, 'false')) }}
+      bq_enable: ${{ fromJSON(inputs.bq_enable || 'false') }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- replace the unsupported `coalesce` expression in the workflow dispatch inputs
- ensure the BigQuery flag falls back to `false` using the supported logical-or syntax

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbcf5b81008330baaeb26702914250