### PR TITLE
Fix dbt step definition in S4 reusable workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -330,7 +330,6 @@ jobs:
           if-no-files-found: warn
 
       - name: dbt run (DuckDB)
-        if: ${{ hashFiles('dbt_project.yml') != '' }}
         if: ${{ !inputs.run_tla && hashFiles('dbt_project.yml') != '' }}
         shell: bash
         run: |
@@ -354,18 +353,6 @@ jobs:
                     temp_directory: "./out/dbt/tmp"
                     memory_limit: "1GB"
             YAML
-ce_profile:
-  target: ci
-  outputs:
-    ci:
-      type: duckdb
-      path: ./out/dbt/ce.duckdb
-      threads: 4
-      extensions: [httpfs]
-      settings:
-        temp_directory: "./out/dbt/tmp"
-        memory_limit: "1GB"
-YAML
           fi
           dbt deps --profiles-dir "$HOME/.dbt" --profile ce_profile
           dbt debug --profiles-dir "$HOME/.dbt" --profile ce_profile


### PR DESCRIPTION
## Summary
- remove the duplicated `if` clause before the dbt step in the reusable workflow
- drop the stray heredoc block so the workflow YAML parses correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68fbd02256c08330889730d36c0ad653