### PR TITLE
Fix dbt DuckDB profile heredoc in ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -341,18 +341,18 @@ jobs:
             cp ops/dbt/profiles_duckdb.yml "$HOME/.dbt/profiles.yml"
           else
             cat > "$HOME/.dbt/profiles.yml" <<'YAML'
-            ce_profile:
-              target: ci
-              outputs:
-                ci:
-                  type: duckdb
-                  path: ./out/dbt/ce.duckdb
-                  threads: 4
-                  extensions: [httpfs]
-                  settings:
-                    temp_directory: "./out/dbt/tmp"
-                    memory_limit: "1GB"
-            YAML
+ce_profile:
+  target: ci
+  outputs:
+    ci:
+      type: duckdb
+      path: ./out/dbt/ce.duckdb
+      threads: 4
+      extensions: [httpfs]
+      settings:
+        temp_directory: "./out/dbt/tmp"
+        memory_limit: "1GB"
+YAML
           fi
           dbt deps --profiles-dir "$HOME/.dbt" --profile ce_profile
           dbt debug --profiles-dir "$HOME/.dbt" --profile ce_profile


### PR DESCRIPTION
## Summary
- fix the inline dbt DuckDB profile generation in the reusable ORR workflow so the heredoc terminator is recognized
- ensure the generated YAML matches the expected indentation without being treated as part of the script

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fbd1a7b3308330b17d5fb17239833d