### PR TITLE
Fix boolean forwarding in s4 exec workflow

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -32,5 +32,5 @@ jobs:
       ref: ${{ inputs.ref }}
       run_microbench: ${{ inputs.run_microbench }}
       run_tla: ${{ inputs.run_tla }}
-      bq_enable: ${{ fromJSON(inputs.bq_enable || 'false') }}
+      bq_enable: ${{ inputs.bq_enable }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- update the S4 exec dispatcher workflow to pass the BigQuery toggle input directly to the reusable workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbd37b0f408330a18fd279b4bb6b5d