### PR TITLE
Add run_sut toggle to s4 exec workflow

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_sut:
+        description: Start SUT via docker-compose
+        required: false
+        type: boolean
+        default: false
       bq_enable:
         description: "Habilitar rota BigQuery"
         required: false
@@ -32,5 +37,6 @@ jobs:
       ref: ${{ inputs.ref }}
       run_microbench: ${{ inputs.run_microbench }}
       run_tla: ${{ inputs.run_tla }}
+      run_sut: ${{ fromJSON(github.event.inputs.run_sut || 'false') }}
       bq_enable: ${{ inputs.bq_enable }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- add the run_sut boolean input to the s4 exec workflow dispatch form
- forward the run_sut value to the reusable S4 ORR workflow

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68fbdabf7edc8330b5bb8f47a1b36bf7