### PR TITLE
Fix Apalache workflow permissions

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -303,20 +303,26 @@ jobs:
           MODULE="$(basename "$SEL")"
           MOUNT_PATH="$PWD/$WORK"
 
-          {
+          { 
             echo "[tla] Using image: ${APAL_IMG}"
             echo "[tla] Selected module: ${MODULE}"
             echo "[tla] Workspace: ${WORK}"
           } | tee -a "$REPORT"
 
+          APAL_UID="$(id -u)"
+          APAL_GID="$(id -g)"
+
           set +e
           docker run --rm \
+            --user "${APAL_UID}:${APAL_GID}" \
             -v "${MOUNT_PATH}:/var/apalache" \
             -w /var/apalache \
             "$APAL_IMG" \
             check "$MODULE" | tee -a "$REPORT"
           RC=${PIPESTATUS[0]}
           set -e
+
+          chmod -R u+rwX,go+rX "$WORK"
 
           echo "[tla] Exit code: ${RC}" | tee -a "$REPORT"
           exit "$RC"


### PR DESCRIPTION
## Summary
- capture the runner UID and GID before invoking the Apalache container
- run Apalache as the runner user and relax workspace permissions after execution to avoid EACCES during artifact upload

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68fbdd7bb5b48330a284e402a095ccf9