### PR TITLE
Fix Apalache workflow permissions

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -311,10 +311,13 @@ jobs:
 
           APAL_UID="$(id -u)"
           APAL_GID="$(id -g)"
+          APAL_USER="$(id -un)"
 
           set +e
           docker run --rm \
-            --user "${APAL_UID}:${APAL_GID}" \
+            -e "APAL_UID=${APAL_UID}" \
+            -e "APAL_GID=${APAL_GID}" \
+            -e "APAL_USER=${APAL_USER}" \
             -v "${MOUNT_PATH}:/var/apalache" \
             -w /var/apalache \
             "$APAL_IMG" \
@@ -322,7 +325,12 @@ jobs:
           RC=${PIPESTATUS[0]}
           set -e
 
-          chmod -R u+rwX,go+rX "$WORK"
+          if command -v sudo >/dev/null 2>&1; then
+            sudo chown -R "${APAL_UID}:${APAL_GID}" "$WORK" || true
+            sudo chmod -R u+rwX,go+rX "$WORK" || true
+          else
+            chmod -R u+rwX,go+rX "$WORK" || true
+          fi
 
           echo "[tla] Exit code: ${RC}" | tee -a "$REPORT"
           exit "$RC"


### PR DESCRIPTION
## Summary
- pass the GitHub runner uid, gid, and username to the Apalache container instead of forcing --user
- restore ownership and permissions on the Apalache workspace using sudo when available to keep artifacts accessible

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68fbe04914388330bbd96f66a6700aa4