### PR TITLE
Add auto-resolution service with audit logging and tests

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer packages for trendmarketv2."""

--- a/services/auto_resolution/__init__.py
+++ b/services/auto_resolution/__init__.py
@@ -1,0 +1,20 @@
+"""Auto-resolution service package."""
+from .service import (
+    ALLOWED_AUTO_ROLES,
+    ALLOWED_MANUAL_ROLES,
+    AutoResolutionService,
+    ResolutionError,
+    ResolutionRecord,
+    TruthSourceSignal,
+)
+from .api import apply_resolution
+
+__all__ = [
+    "ALLOWED_AUTO_ROLES",
+    "ALLOWED_MANUAL_ROLES",
+    "AutoResolutionService",
+    "ResolutionError",
+    "ResolutionRecord",
+    "TruthSourceSignal",
+    "apply_resolution",
+]

--- a/services/auto_resolution/api.py
+++ b/services/auto_resolution/api.py
@@ -1,0 +1,66 @@
+"""Thin API handler for `/resolve/apply` requests."""
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+import time
+
+from .service import AutoResolutionService, ResolutionRecord, TruthSourceSignal
+
+
+def apply_resolution(payload: Mapping[str, Any], *, service: AutoResolutionService) -> Dict[str, Any]:
+    """Process a `/resolve/apply` request using the provided service."""
+
+    required_fields = {"event_id", "quorum_votes", "actor", "role", "idempotency_key"}
+    missing = required_fields - payload.keys()
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise ValueError(f"Missing required fields: {missing_str}")
+
+    truth_source_signal = _build_truth_source(payload.get("truth_source"))
+    record = service.apply(
+        event_id=str(payload["event_id"]),
+        quorum_votes=_normalize_votes(payload.get("quorum_votes", [])),
+        actor=str(payload["actor"]),
+        role=str(payload["role"]),
+        idempotency_key=str(payload["idempotency_key"]),
+        trace_id=payload.get("trace_id"),
+        truth_source=truth_source_signal,
+        manual_override=payload.get("manual_override"),
+        manual_reason=payload.get("manual_reason"),
+        evidence_uri=payload.get("evidence_uri"),
+    )
+    return _format_response(record)
+
+
+def _normalize_votes(votes: Any) -> list[str]:
+    if isinstance(votes, (list, tuple)):
+        return [str(vote) for vote in votes]
+    raise ValueError("quorum_votes must be a sequence of strings")
+
+
+def _build_truth_source(data: Optional[Mapping[str, Any]]) -> Optional[TruthSourceSignal]:
+    if not data:
+        return None
+    observed_at = data.get("observed_at") or time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return TruthSourceSignal(
+        source=str(data.get("source", "unknown")),
+        verdict=str(data.get("verdict", "")).lower(),
+        confidence=float(data.get("confidence", 0.0)),
+        observed_at=str(observed_at),
+        evidence_uri=data.get("evidence_uri"),
+        notes=data.get("notes"),
+    )
+
+
+def _format_response(record: ResolutionRecord) -> Dict[str, Any]:
+    return {
+        "decision_id": record.trace_id,
+        "outcome": record.outcome,
+        "reason": record.reason,
+        "quorum_ok": record.quorum_ok,
+        "truth_source_used": record.truth_source_used,
+        "manual_override": record.manual_override,
+    }
+
+
+__all__ = ["apply_resolution"]

--- a/services/auto_resolution/service.py
+++ b/services/auto_resolution/service.py
@@ -1,0 +1,229 @@
+"""Auto-resolution service combining quorum evaluation and truth-source overrides."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from hashlib import sha256
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+import json
+import time
+import uuid
+
+ALLOWED_AUTO_ROLES = {"resolver", "admin", "resolver_lead"}
+ALLOWED_MANUAL_ROLES = {"admin", "resolver_lead"}
+
+
+class ResolutionError(RuntimeError):
+    """Raised when a resolution cannot be applied automatically."""
+
+
+@dataclass
+class TruthSourceSignal:
+    """Signal reported by the configured truth source."""
+
+    source: str
+    verdict: str
+    confidence: float
+    observed_at: str
+    evidence_uri: Optional[str] = None
+    notes: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.verdict = self.verdict.lower()
+        if self.verdict not in {"accepted", "rejected"}:
+            raise ValueError("Truth source verdict must be 'accepted' or 'rejected'")
+        if not (0.0 <= self.confidence <= 1.0):
+            raise ValueError("Truth source confidence must be between 0.0 and 1.0")
+
+
+@dataclass
+class ResolutionRecord:
+    """Outcome of an auto-resolution attempt."""
+
+    event_id: str
+    outcome: str
+    reason: str
+    trace_id: str
+    decided_at: float
+    idempotency_key: str
+    quorum_ok: bool
+    truth_source_used: bool
+    manual_override: bool
+
+
+class AutoResolutionService:
+    """Evaluate quorum decisions with truth-source overrides and audit logging."""
+
+    def __init__(
+        self,
+        *,
+        audit_log: Path,
+        quorum_threshold: float = 2 / 3,
+        truth_confidence_threshold: float = 0.7,
+    ) -> None:
+        self.audit_log = audit_log
+        self.audit_log.parent.mkdir(parents=True, exist_ok=True)
+        self.quorum_threshold = quorum_threshold
+        self.truth_confidence_threshold = truth_confidence_threshold
+        self._idempotency: Dict[str, ResolutionRecord] = {}
+
+    def apply(
+        self,
+        *,
+        event_id: str,
+        quorum_votes: Sequence[str],
+        actor: str,
+        role: str,
+        idempotency_key: str,
+        trace_id: Optional[str] = None,
+        truth_source: Optional[TruthSourceSignal] = None,
+        manual_override: Optional[str] = None,
+        manual_reason: Optional[str] = None,
+        evidence_uri: Optional[str] = None,
+    ) -> ResolutionRecord:
+        self._require_idempotency_key(idempotency_key)
+        existing = self._idempotency.get(idempotency_key)
+        if existing is not None:
+            if existing.event_id != event_id:
+                raise ResolutionError("Idempotency key reuse for different event is not allowed")
+            return existing
+
+        normalized_votes = [vote.lower() for vote in quorum_votes]
+        self._enforce_role(role, ALLOWED_AUTO_ROLES, action="apply resolution")
+
+        if manual_override is not None:
+            self._enforce_role(role, ALLOWED_MANUAL_ROLES, action="perform manual override")
+            outcome, truth_used, reason = self._apply_manual_override(manual_override, manual_reason)
+            manual_flag = True
+            quorum_ok = self._quorum_reached(normalized_votes)
+        else:
+            manual_flag = False
+            outcome, truth_used, reason, quorum_ok = self._apply_auto_logic(
+                normalized_votes, truth_source
+            )
+
+        decided_at = time.time()
+        resolved_trace = trace_id or uuid.uuid4().hex
+        record = ResolutionRecord(
+            event_id=event_id,
+            outcome=outcome,
+            reason=reason,
+            trace_id=resolved_trace,
+            decided_at=decided_at,
+            idempotency_key=idempotency_key,
+            quorum_ok=quorum_ok,
+            truth_source_used=truth_used,
+            manual_override=manual_flag,
+        )
+        self._idempotency[idempotency_key] = record
+        self._append_audit(
+            actor=actor,
+            role=role,
+            record=record,
+            quorum_votes=normalized_votes,
+            truth_source=truth_source,
+            manual_reason=manual_reason,
+            evidence_uri=evidence_uri,
+        )
+        return record
+
+    def _apply_manual_override(
+        self, manual_override: str, manual_reason: Optional[str]
+    ) -> tuple[str, bool, str]:
+        normalized = manual_override.lower()
+        if normalized not in {"accepted", "rejected"}:
+            raise ValueError("Manual override must be 'accepted' or 'rejected'")
+        reason = manual_reason or "manual_override"
+        return normalized, False, reason
+
+    def _apply_auto_logic(
+        self, quorum_votes: Sequence[str], truth_source: Optional[TruthSourceSignal]
+    ) -> tuple[str, bool, str, bool]:
+        quorum_ok = self._quorum_reached(quorum_votes)
+        majority_accepts = self._majority_accepts(quorum_votes)
+
+        if truth_source and truth_source.confidence >= self.truth_confidence_threshold:
+            return truth_source.verdict, True, f"truth_source:{truth_source.source}", quorum_ok
+
+        if quorum_ok:
+            reason = "quorum"
+            outcome = "accepted" if majority_accepts else "rejected"
+            return outcome, False, reason, quorum_ok
+
+        raise ResolutionError(
+            "Quorum not reached and no reliable truth source or manual override provided"
+        )
+
+    def _append_audit(
+        self,
+        *,
+        actor: str,
+        role: str,
+        record: ResolutionRecord,
+        quorum_votes: Sequence[str],
+        truth_source: Optional[TruthSourceSignal],
+        manual_reason: Optional[str],
+        evidence_uri: Optional[str],
+    ) -> None:
+        payload = {
+            "event_id": record.event_id,
+            "quorum_votes": list(quorum_votes),
+            "truth_source": asdict(truth_source) if truth_source else None,
+            "outcome": record.outcome,
+            "reason": record.reason,
+            "manual_reason": manual_reason,
+            "evidence_uri": evidence_uri,
+            "idempotency_key": record.idempotency_key,
+        }
+        payload_hash = sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+        entry = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(record.decided_at)),
+            "actor": actor,
+            "role": role,
+            "action": "auto_resolve.apply",
+            "target": record.event_id,
+            "payload_hash": payload_hash,
+            "trace_id": record.trace_id,
+            "outcome": record.outcome,
+            "idempotency_key": record.idempotency_key,
+            "manual_override": record.manual_override,
+            "truth_source_used": record.truth_source_used,
+            "quorum_ok": record.quorum_ok,
+        }
+        with self.audit_log.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+
+    def _quorum_reached(self, votes: Sequence[str]) -> bool:
+        if not votes:
+            return False
+        support = sum(1 for vote in votes if vote == "accepted")
+        ratio = support / len(votes)
+        return ratio >= self.quorum_threshold
+
+    def _majority_accepts(self, votes: Sequence[str]) -> bool:
+        support = sum(1 for vote in votes if vote == "accepted")
+        return support >= (len(votes) - support)
+
+    def _enforce_role(self, role: str, allowed: Iterable[str], *, action: str) -> None:
+        if role not in allowed:
+            raise PermissionError(f"Role '{role}' not permitted to {action}")
+
+    def _require_idempotency_key(self, key: str) -> None:
+        if not key or len(key) < 8:
+            raise ValueError("idempotency_key must be at least 8 characters long")
+
+    def load_audit_entries(self) -> List[Dict[str, object]]:
+        if not self.audit_log.exists():
+            return []
+        with self.audit_log.open("r", encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+
+
+__all__ = [
+    "ALLOWED_AUTO_ROLES",
+    "ALLOWED_MANUAL_ROLES",
+    "AutoResolutionService",
+    "ResolutionError",
+    "ResolutionRecord",
+    "TruthSourceSignal",
+]

--- a/tests/integration/test_auto_resolution_api.py
+++ b/tests/integration/test_auto_resolution_api.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.auto_resolution import AutoResolutionService, apply_resolution  # noqa: E402
+
+
+def _service(tmp_path: Path) -> AutoResolutionService:
+    audit_path = tmp_path / "audit" / "auto_resolve.log"
+    return AutoResolutionService(audit_log=audit_path)
+
+
+def test_apply_resolution_handler_idempotency(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    payload = {
+        "event_id": "evt-api-1",
+        "quorum_votes": ["accepted", "accepted", "rejected"],
+        "actor": "zoe",
+        "role": "resolver",
+        "idempotency_key": "idem-api-1234",
+    }
+
+    first = apply_resolution(payload, service=service)
+    assert first["outcome"] == "accepted"
+    assert first["decision_id"]
+    assert first["truth_source_used"] is False
+
+    second = apply_resolution(payload, service=service)
+    assert second == first
+
+    entries = service.load_audit_entries()
+    assert len(entries) == 1
+    assert entries[0]["idempotency_key"] == "idem-api-1234"
+
+
+def test_apply_resolution_manual_fallback(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    payload = {
+        "event_id": "evt-api-2",
+        "quorum_votes": ["accepted", "rejected"],
+        "actor": "ivy",
+        "role": "admin",
+        "idempotency_key": "idem-api-5678",
+        "manual_override": "rejected",
+        "manual_reason": "insufficient quorum",
+    }
+
+    result = apply_resolution(payload, service=service)
+    assert result["outcome"] == "rejected"
+    assert result["manual_override"] is True
+    assert result["truth_source_used"] is False
+
+
+def test_apply_resolution_requires_fields(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    with pytest.raises(ValueError):
+        apply_resolution({"event_id": "evt"}, service=service)

--- a/tests/unit/auto_resolution/test_service.py
+++ b/tests/unit/auto_resolution/test_service.py
@@ -1,0 +1,132 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.auto_resolution.service import (  # noqa: E402
+    ALLOWED_AUTO_ROLES,
+    ALLOWED_MANUAL_ROLES,
+    AutoResolutionService,
+    ResolutionError,
+    TruthSourceSignal,
+)
+
+
+def _service(tmp_path: Path) -> AutoResolutionService:
+    audit_path = tmp_path / "audit" / "auto_resolve.log"
+    return AutoResolutionService(audit_log=audit_path)
+
+
+def test_quorum_resolution_success(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    record = service.apply(
+        event_id="evt-1",
+        quorum_votes=["accepted", "accepted", "rejected"],
+        actor="alice",
+        role=sorted(ALLOWED_AUTO_ROLES)[0],
+        idempotency_key="idem-123456",
+    )
+    assert record.outcome == "accepted"
+    assert record.truth_source_used is False
+    assert record.quorum_ok is True
+
+    audit_entries = service.load_audit_entries()
+    assert len(audit_entries) == 1
+    assert audit_entries[0]["action"] == "auto_resolve.apply"
+
+
+def test_truth_source_override(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    truth = TruthSourceSignal(
+        source="trusted_feed",
+        verdict="rejected",
+        confidence=0.9,
+        observed_at="2024-05-01T00:00:00Z",
+    )
+
+    record = service.apply(
+        event_id="evt-2",
+        quorum_votes=["accepted", "accepted", "accepted"],
+        actor="bob",
+        role="resolver",
+        idempotency_key="idem-654321",
+        truth_source=truth,
+    )
+    assert record.outcome == "rejected"
+    assert record.truth_source_used is True
+    assert record.quorum_ok is True
+
+
+def test_quorum_failure_requires_manual_or_truth_source(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    with pytest.raises(ResolutionError):
+        service.apply(
+            event_id="evt-3",
+            quorum_votes=["accepted", "rejected"],
+            actor="carol",
+            role="resolver",
+            idempotency_key="idem-abcdef",
+        )
+
+
+def test_manual_override_requires_role(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    with pytest.raises(PermissionError):
+        service.apply(
+            event_id="evt-4",
+            quorum_votes=["rejected", "rejected", "accepted"],
+            actor="mallory",
+            role="resolver",
+            idempotency_key="idem-override",
+            manual_override="accepted",
+        )
+
+    # Valid manual override by a privileged role
+    privileged_role = sorted(ALLOWED_MANUAL_ROLES)[0]
+    record = service.apply(
+        event_id="evt-4",
+        quorum_votes=["rejected", "rejected", "accepted"],
+        actor="dave",
+        role=privileged_role,
+        idempotency_key="idem-override2",
+        manual_override="accepted",
+        manual_reason="committee decision",
+    )
+    assert record.outcome == "accepted"
+    assert record.manual_override is True
+    assert record.truth_source_used is False
+
+
+def test_idempotency_returns_same_record(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    record = service.apply(
+        event_id="evt-5",
+        quorum_votes=["accepted", "accepted", "rejected"],
+        actor="erin",
+        role="resolver",
+        idempotency_key="idem-unique",
+    )
+
+    repeat = service.apply(
+        event_id="evt-5",
+        quorum_votes=["rejected", "rejected", "rejected"],
+        actor="erin",
+        role="resolver",
+        idempotency_key="idem-unique",
+    )
+    assert repeat is record
+
+    with pytest.raises(ResolutionError):
+        service.apply(
+            event_id="evt-other",
+            quorum_votes=["accepted", "accepted", "rejected"],
+            actor="erin",
+            role="resolver",
+            idempotency_key="idem-unique",
+        )


### PR DESCRIPTION
## Summary
- add an auto-resolution service that combines quorum evaluation, truth-source overrides, manual fallback, and JSONL audit logging
- expose the service through a /resolve/apply API handler with RBAC and idempotency safeguards
- cover quorum success/failure, truth-source overrides, and audit persistence with new unit and integration tests

## Testing
- pytest tests/unit/auto_resolution tests/integration/test_auto_resolution_api.py

------
https://chatgpt.com/codex/tasks/task_e_68fc1b862f848330b7c6c832287d3ed7