### PR TITLE
Add dbt staging and marts for simulation and moderation data

### DIFF
--- a/fixtures/moderation_events.csv
+++ b/fixtures/moderation_events.csv
@@ -1,0 +1,4 @@
+id,ts,symbol,action,reason,evidence_uri,actor
+mod_20240101_pause,2024-01-01T00:05:00Z,BRLUSD,pause,divergence>1%,s3://moderation/events/pause.json,auto_resolver
+mod_20240101_resume,2024-01-01T00:12:00Z,BRLUSD,resume,quorum_restored,s3://moderation/events/resume.json,moderator_bot
+mod_20240101_review,2024-01-01T00:20:00Z,BRLUSD,review,manual_audit,s3://moderation/events/review.json,human_analyst

--- a/fixtures/simulation_runs.csv
+++ b/fixtures/simulation_runs.csv
@@ -1,0 +1,4 @@
+id,scenario,started_at,finished_at,p95_latency_ms,result_path
+run_20240101_spike,spike,2024-01-01T00:00:00Z,2024-01-01T00:03:10Z,620,s3://simulations/reports/spike.json
+run_20240101_gap,gap,2024-01-01T00:05:00Z,2024-01-01T00:07:45Z,710,s3://simulations/reports/gap.json
+run_20240101_burst,burst,2024-01-01T00:10:00Z,2024-01-01T00:16:30Z,780,s3://simulations/reports/burst.json

--- a/models/marts/mrt_moderation_events.sql
+++ b/models/marts/mrt_moderation_events.sql
@@ -1,0 +1,30 @@
+{{ config(materialized='table') }}
+
+with ranked_events as (
+    select
+        id,
+        ts,
+        symbol,
+        action,
+        reason,
+        evidence_uri,
+        actor,
+        row_number() over (partition by symbol order by ts desc) as event_rank
+    from {{ ref('stg_moderation_events') }}
+    where action in ('pause', 'resume', 'review')
+),
+latest_events as (
+    select
+        id,
+        ts,
+        symbol,
+        action,
+        reason,
+        evidence_uri,
+        actor
+    from ranked_events
+    where event_rank <= 3
+)
+
+select *
+from latest_events;

--- a/models/marts/mrt_simulation_runs.sql
+++ b/models/marts/mrt_simulation_runs.sql
@@ -1,0 +1,28 @@
+{{ config(materialized='table') }}
+
+with ranked_runs as (
+    select
+        id,
+        scenario,
+        started_at,
+        finished_at,
+        p95_latency_ms,
+        result_path,
+        row_number() over (partition by scenario order by finished_at desc) as scenario_rank
+    from {{ ref('stg_simulation_runs') }}
+),
+filtered_runs as (
+    select
+        id,
+        scenario,
+        started_at,
+        finished_at,
+        p95_latency_ms,
+        result_path
+    from ranked_runs
+    where scenario_rank = 1
+      and p95_latency_ms <= 800
+)
+
+select *
+from filtered_runs;

--- a/models/staging/stg_moderation_events.sql
+++ b/models/staging/stg_moderation_events.sql
@@ -1,0 +1,31 @@
+{{ config(materialized='table') }}
+
+with raw_events as (
+    select
+        id,
+        ts,
+        symbol,
+        action,
+        reason,
+        evidence_uri,
+        actor
+    from read_csv_auto('fixtures/moderation_events.csv',
+                       header=True,
+                       types={'id': 'VARCHAR',
+                              'ts': 'TIMESTAMP WITH TIME ZONE',
+                              'symbol': 'VARCHAR',
+                              'action': 'VARCHAR',
+                              'reason': 'VARCHAR',
+                              'evidence_uri': 'VARCHAR',
+                              'actor': 'VARCHAR'})
+)
+
+select
+    id,
+    ts,
+    symbol,
+    action,
+    reason,
+    evidence_uri,
+    actor
+from raw_events;

--- a/models/staging/stg_simulation_runs.sql
+++ b/models/staging/stg_simulation_runs.sql
@@ -1,0 +1,28 @@
+{{ config(materialized='table') }}
+
+with raw_runs as (
+    select
+        id,
+        scenario,
+        started_at,
+        finished_at,
+        p95_latency_ms,
+        result_path
+    from read_csv_auto('fixtures/simulation_runs.csv',
+                       header=True,
+                       types={'id': 'VARCHAR',
+                              'scenario': 'VARCHAR',
+                              'started_at': 'TIMESTAMP WITH TIME ZONE',
+                              'finished_at': 'TIMESTAMP WITH TIME ZONE',
+                              'p95_latency_ms': 'INTEGER',
+                              'result_path': 'VARCHAR'})
+)
+
+select
+    id,
+    scenario,
+    started_at,
+    finished_at,
+    p95_latency_ms,
+    result_path
+from raw_runs;

--- a/models/tests/mrt_moderation_events.yml
+++ b/models/tests/mrt_moderation_events.yml
@@ -1,0 +1,28 @@
+version: 2
+models:
+  - name: mrt_moderation_events
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: ts
+        tests:
+          - not_null
+      - name: symbol
+        tests:
+          - not_null
+      - name: action
+        tests:
+          - not_null
+          - accepted_values:
+              values: [pause, resume, review]
+      - name: reason
+        tests:
+          - not_null
+      - name: evidence_uri
+        tests:
+          - not_null
+      - name: actor
+        tests:
+          - not_null

--- a/models/tests/mrt_moderation_events_freshness.sql
+++ b/models/tests/mrt_moderation_events_freshness.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('mrt_moderation_events') }}
+where ts < timestamp '2024-01-01 00:00:00';

--- a/models/tests/mrt_simulation_runs.yml
+++ b/models/tests/mrt_simulation_runs.yml
@@ -1,0 +1,25 @@
+version: 2
+models:
+  - name: mrt_simulation_runs
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: scenario
+        tests:
+          - not_null
+          - accepted_values:
+              values: [spike, gap, burst]
+      - name: started_at
+        tests:
+          - not_null
+      - name: finished_at
+        tests:
+          - not_null
+      - name: p95_latency_ms
+        tests:
+          - not_null
+      - name: result_path
+        tests:
+          - not_null

--- a/models/tests/mrt_simulation_runs_freshness.sql
+++ b/models/tests/mrt_simulation_runs_freshness.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('mrt_simulation_runs') }}
+where p95_latency_ms > 800;

--- a/models/tests/stg_moderation_events.yml
+++ b/models/tests/stg_moderation_events.yml
@@ -1,0 +1,28 @@
+version: 2
+models:
+  - name: stg_moderation_events
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: ts
+        tests:
+          - not_null
+      - name: symbol
+        tests:
+          - not_null
+      - name: action
+        tests:
+          - not_null
+          - accepted_values:
+              values: [pause, resume, review]
+      - name: reason
+        tests:
+          - not_null
+      - name: evidence_uri
+        tests:
+          - not_null
+      - name: actor
+        tests:
+          - not_null

--- a/models/tests/stg_moderation_events_freshness.sql
+++ b/models/tests/stg_moderation_events_freshness.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('stg_moderation_events') }}
+where ts < timestamp '2024-01-01 00:00:00';

--- a/models/tests/stg_simulation_runs.yml
+++ b/models/tests/stg_simulation_runs.yml
@@ -1,0 +1,25 @@
+version: 2
+models:
+  - name: stg_simulation_runs
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: scenario
+        tests:
+          - not_null
+          - accepted_values:
+              values: [spike, gap, burst]
+      - name: started_at
+        tests:
+          - not_null
+      - name: finished_at
+        tests:
+          - not_null
+      - name: p95_latency_ms
+        tests:
+          - not_null
+      - name: result_path
+        tests:
+          - not_null

--- a/models/tests/stg_simulation_runs_freshness.sql
+++ b/models/tests/stg_simulation_runs_freshness.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('stg_simulation_runs') }}
+where finished_at - started_at > interval '5 minutes';


### PR DESCRIPTION
## Summary
- add fixture CSVs for simulation runs and moderation events to backfill DuckDB sources
- build staging models that load the fixtures and marts that curate the latest contract-compliant records
- register schema- and freshness-style tests for the new staging and mart models to enforce Sprint 5 data contracts

## Testing
- ⚠️ `pip install 'dbt-duckdb~=1.8.0'` *(fails: repository access is blocked by the execution environment)*
- ⚠️ `dbt run` *(not run: dbt is unavailable in the execution environment)*
- ⚠️ `dbt test` *(not run: dbt is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc1b8667448330add85aab441a3d3e