### PR TITLE
Implement auto-resolution service and handler

### DIFF
--- a/services/auto_resolution/__init__.py
+++ b/services/auto_resolution/__init__.py
@@ -1,0 +1,27 @@
+"""Auto-resolution service module."""
+from .api import AutoResolutionAPI, InvalidRequest
+from .resolver import (
+    ALLOWED_RESOLUTION_ROLES,
+    AutoResolutionDecision,
+    AutoResolutionService,
+    DecisionConflict,
+    DecisionRule,
+    IdempotencyKeyConflict,
+    ManualOverride,
+    QuorumEvaluation,
+    TruthSourcePayload,
+)
+
+__all__ = [
+    "ALLOWED_RESOLUTION_ROLES",
+    "AutoResolutionAPI",
+    "AutoResolutionDecision",
+    "AutoResolutionService",
+    "DecisionConflict",
+    "DecisionRule",
+    "IdempotencyKeyConflict",
+    "InvalidRequest",
+    "ManualOverride",
+    "QuorumEvaluation",
+    "TruthSourcePayload",
+]

--- a/services/auto_resolution/api.py
+++ b/services/auto_resolution/api.py
@@ -1,0 +1,118 @@
+"""In-process API facade for the auto-resolution service."""
+from __future__ import annotations
+
+from typing import Dict, Mapping, Optional
+
+from .resolver import (
+    AutoResolutionDecision,
+    AutoResolutionService,
+    ManualOverride,
+    QuorumEvaluation,
+    TruthSourcePayload,
+)
+
+
+class InvalidRequest(ValueError):
+    """Raised when the incoming payload violates API expectations."""
+
+
+class AutoResolutionAPI:
+    """Lightweight handler exposing ``/resolve/apply`` semantics."""
+
+    def __init__(self, service: AutoResolutionService) -> None:
+        self.service = service
+
+    def resolve_apply(
+        self,
+        body: Mapping[str, object],
+        *,
+        actor: str,
+        role: str,
+        idempotency_key: str,
+        trace_id: Optional[str] = None,
+    ) -> Dict[str, object]:
+        schema_version = body.get("schema_version")
+        if schema_version != 1:
+            raise InvalidRequest("Unsupported schema_version")
+
+        decision_id = self._require_field(body, "decision_id")
+        truth_source_name = self._require_field(body, "truth_source")
+        quorum_flag = bool(body.get("quorum", False))
+        payload_obj = body.get("payload") or {}
+
+        truth_section = self._ensure_mapping(payload_obj.get("truth"), "truth")
+        quorum_section = self._ensure_mapping(payload_obj.get("quorum"), "quorum")
+        manual_override_section = payload_obj.get("manual_override")
+
+        truth_payload = TruthSourcePayload(
+            source=str(truth_source_name),
+            status=str(truth_section.get("status", "pending")),
+            verdict=truth_section.get("verdict"),
+            confidence=float(truth_section.get("confidence", 0.0)),
+            ts=truth_section.get("ts"),
+            evidence_uri=truth_section.get("evidence_uri"),
+        )
+
+        quorum_result = QuorumEvaluation(
+            quorum_ok=quorum_flag,
+            suggested_outcome=quorum_section.get("outcome"),
+            confidence=self._optional_float(quorum_section.get("confidence")),
+            contributors=list(quorum_section.get("contributors", [])),
+        )
+
+        manual_override = self._parse_manual_override(manual_override_section)
+
+        metadata = {
+            key: value
+            for key, value in payload_obj.items()
+            if key not in {"truth", "quorum", "manual_override"}
+        }
+
+        decision: AutoResolutionDecision = self.service.apply_resolution(
+            decision_id=decision_id,
+            truth_payload=truth_payload,
+            quorum_result=quorum_result,
+            actor=actor,
+            role=role,
+            idempotency_key=idempotency_key,
+            manual_override=manual_override,
+            metadata=metadata,
+            trace_id=trace_id,
+        )
+        return decision.as_dict()
+
+    def _require_field(self, payload: Mapping[str, object], field: str) -> object:
+        value = payload.get(field)
+        if value is None:
+            raise InvalidRequest(f"Missing field: {field}")
+        return value
+
+    def _ensure_mapping(self, obj: object, field: str) -> Mapping[str, object]:
+        if obj is None:
+            return {}
+        if not isinstance(obj, Mapping):
+            raise InvalidRequest(f"Section '{field}' must be an object")
+        return obj
+
+    def _parse_manual_override(self, override: object) -> Optional[ManualOverride]:
+        if override is None:
+            return None
+        if isinstance(override, str):
+            if not override:
+                raise InvalidRequest("manual_override outcome cannot be empty")
+            return ManualOverride(outcome=override)
+        if not isinstance(override, Mapping):
+            raise InvalidRequest("manual_override must be an object or string")
+        outcome = override.get("outcome")
+        if not outcome:
+            raise InvalidRequest("manual_override requires an outcome")
+        reason = override.get("reason")
+        return ManualOverride(outcome=str(outcome), reason=str(reason) if reason is not None else None)
+
+    def _optional_float(self, value: object) -> Optional[float]:
+        if value is None:
+            return None
+        return float(value)
+
+
+__all__ = ["AutoResolutionAPI", "InvalidRequest"]

--- a/services/auto_resolution/resolver.py
+++ b/services/auto_resolution/resolver.py
@@ -1,0 +1,279 @@
+"""Auto-resolution service with Sprint 5 decision rules and audit logging."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+import json
+import time
+import uuid
+
+ALLOWED_RESOLUTION_ROLES = {"resolver", "admin"}
+
+
+class IdempotencyKeyConflict(RuntimeError):
+    """Raised when an idempotency key is reused with mismatched payloads."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__(f"Idempotency key '{key}' conflict")
+        self.key = key
+
+
+class DecisionConflict(RuntimeError):
+    """Raised when a decision has already been recorded with another outcome."""
+
+    def __init__(self, decision_id: str) -> None:
+        super().__init__(f"Decision '{decision_id}' conflict")
+        self.decision_id = decision_id
+
+
+class DecisionRule:
+    """Enumeration of Sprint 5 auto-resolution decision rules."""
+
+    TRUTH_SOURCE_FINAL = "truth_source_final"
+    TRUTH_SOURCE_OVERRIDE = "truth_source_override"
+    QUORUM_CONSENSUS = "quorum_consensus"
+    MANUAL_OVERRIDE = "manual_override"
+    MANUAL_REVIEW = "manual_review_required"
+
+
+@dataclass(frozen=True)
+class TruthSourcePayload:
+    """Structured payload emitted by an authoritative truth source."""
+
+    source: str
+    status: str
+    verdict: Optional[str]
+    confidence: float
+    ts: Optional[str] = None
+    evidence_uri: Optional[str] = None
+
+    def is_final(self) -> bool:
+        """Return ``True`` when the truth source payload is considered final."""
+
+        return self.status.lower() in {"final", "confirmed"}
+
+
+@dataclass(frozen=True)
+class QuorumEvaluation:
+    """Result of quorum aggregation for the disputed market."""
+
+    quorum_ok: bool
+    suggested_outcome: Optional[str]
+    confidence: Optional[float] = None
+    contributors: Optional[List[str]] = None
+
+
+@dataclass(frozen=True)
+class ManualOverride:
+    """Manual override supplied by a human operator."""
+
+    outcome: str
+    reason: Optional[str] = None
+
+
+@dataclass
+class AutoResolutionDecision:
+    """Decision emitted by :class:`AutoResolutionService`."""
+
+    decision_id: str
+    outcome: str
+    rule: str
+    trace_id: str
+    actor: str
+    role: str
+    idempotency_key: str
+    metadata: Dict[str, object]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "decision_id": self.decision_id,
+            "outcome": self.outcome,
+            "rule": self.rule,
+            "trace_id": self.trace_id,
+        }
+
+
+@dataclass
+class _StoredDecision:
+    decision: AutoResolutionDecision
+    payload_hash: str
+
+
+class AutoResolutionService:
+    """Apply Sprint 5 auto-resolution rules with RBAC and audit trail."""
+
+    def __init__(self, audit_log: Path, *, allowed_roles: Optional[Iterable[str]] = None) -> None:
+        self.audit_log = audit_log
+        self.audit_log.parent.mkdir(parents=True, exist_ok=True)
+        self.allowed_roles = set(allowed_roles) if allowed_roles else ALLOWED_RESOLUTION_ROLES
+        self._idempotency: Dict[str, _StoredDecision] = {}
+        self._decisions: Dict[str, AutoResolutionDecision] = {}
+
+    def apply_resolution(
+        self,
+        *,
+        decision_id: str,
+        truth_payload: TruthSourcePayload,
+        quorum_result: QuorumEvaluation,
+        actor: str,
+        role: str,
+        idempotency_key: str,
+        manual_override: Optional[ManualOverride] = None,
+        metadata: Optional[Dict[str, object]] = None,
+        trace_id: Optional[str] = None,
+    ) -> AutoResolutionDecision:
+        self._enforce_role(role)
+
+        resolved_metadata = dict(metadata or {})
+        payload_hash = self._compute_payload_hash(
+            decision_id=decision_id,
+            truth_payload=truth_payload,
+            quorum_result=quorum_result,
+            manual_override=manual_override,
+            metadata=resolved_metadata,
+        )
+
+        if idempotency_key in self._idempotency:
+            stored = self._idempotency[idempotency_key]
+            if stored.payload_hash != payload_hash:
+                raise IdempotencyKeyConflict(idempotency_key)
+            return stored.decision
+
+        outcome, rule = self._determine_outcome(truth_payload, quorum_result, manual_override)
+
+        resolved_trace = trace_id or uuid.uuid4().hex
+        decision = AutoResolutionDecision(
+            decision_id=decision_id,
+            outcome=outcome,
+            rule=rule,
+            trace_id=resolved_trace,
+            actor=actor,
+            role=role,
+            idempotency_key=idempotency_key,
+            metadata=resolved_metadata,
+        )
+
+        if decision_id in self._decisions:
+            previous = self._decisions[decision_id]
+            if previous.outcome != decision.outcome or previous.rule != decision.rule:
+                raise DecisionConflict(decision_id)
+            # Reuse previous decision for deterministic trace id
+            decision.trace_id = previous.trace_id
+            self._idempotency[idempotency_key] = _StoredDecision(decision=previous, payload_hash=payload_hash)
+            return previous
+
+        self._append_audit(
+            actor=actor,
+            role=role,
+            decision=decision,
+            truth_payload=truth_payload,
+            quorum_result=quorum_result,
+            manual_override=manual_override,
+            payload_hash=payload_hash,
+        )
+
+        self._decisions[decision_id] = decision
+        self._idempotency[idempotency_key] = _StoredDecision(decision=decision, payload_hash=payload_hash)
+        return decision
+
+    def load_audit_entries(self) -> List[Dict[str, object]]:
+        if not self.audit_log.exists():
+            return []
+        with self.audit_log.open("r", encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+
+    def _determine_outcome(
+        self,
+        truth_payload: TruthSourcePayload,
+        quorum_result: QuorumEvaluation,
+        manual_override: Optional[ManualOverride],
+    ) -> (str, str):
+        if manual_override is not None:
+            return manual_override.outcome, DecisionRule.MANUAL_OVERRIDE
+
+        truth_verdict = truth_payload.verdict
+        truth_final = truth_payload.is_final() and truth_verdict is not None
+        quorum_ok = quorum_result.quorum_ok and quorum_result.suggested_outcome is not None
+
+        if truth_final:
+            if quorum_ok and quorum_result.suggested_outcome != truth_verdict:
+                return truth_verdict, DecisionRule.TRUTH_SOURCE_OVERRIDE
+            return truth_verdict, DecisionRule.TRUTH_SOURCE_FINAL
+
+        if quorum_ok:
+            return quorum_result.suggested_outcome or "manual_review", DecisionRule.QUORUM_CONSENSUS
+
+        return "manual_review", DecisionRule.MANUAL_REVIEW
+
+    def _compute_payload_hash(
+        self,
+        *,
+        decision_id: str,
+        truth_payload: TruthSourcePayload,
+        quorum_result: QuorumEvaluation,
+        manual_override: Optional[ManualOverride],
+        metadata: Dict[str, object],
+    ) -> str:
+        canonical = {
+            "decision_id": decision_id,
+            "truth_payload": asdict(truth_payload),
+            "quorum_result": asdict(quorum_result),
+            "manual_override": asdict(manual_override) if manual_override else None,
+            "metadata": metadata,
+        }
+        payload = json.dumps(canonical, sort_keys=True, default=str)
+        return sha256(payload.encode("utf-8")).hexdigest()
+
+    def _append_audit(
+        self,
+        *,
+        actor: str,
+        role: str,
+        decision: AutoResolutionDecision,
+        truth_payload: TruthSourcePayload,
+        quorum_result: QuorumEvaluation,
+        manual_override: Optional[ManualOverride],
+        payload_hash: str,
+    ) -> None:
+        ts_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        entry = {
+            "ts": ts_iso,
+            "actor": actor,
+            "role": role,
+            "action": "resolve",
+            "target": decision.decision_id,
+            "payload_hash": payload_hash,
+            "trace_id": decision.trace_id,
+            "outcome": decision.outcome,
+            "rule": decision.rule,
+            "truth_source": truth_payload.source,
+            "truth_status": truth_payload.status,
+            "quorum_ok": quorum_result.quorum_ok,
+        }
+        if truth_payload.verdict is not None:
+            entry["truth_verdict"] = truth_payload.verdict
+        if manual_override is not None:
+            entry["manual_override"] = manual_override.reason or True
+        if decision.metadata:
+            entry["metadata"] = decision.metadata
+        with self.audit_log.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry) + "\n")
+
+    def _enforce_role(self, role: str) -> None:
+        if role not in self.allowed_roles:
+            raise PermissionError(f"Role '{role}' not permitted to resolve decisions")
+
+
+__all__ = [
+    "ALLOWED_RESOLUTION_ROLES",
+    "AutoResolutionDecision",
+    "AutoResolutionService",
+    "DecisionConflict",
+    "DecisionRule",
+    "IdempotencyKeyConflict",
+    "ManualOverride",
+    "QuorumEvaluation",
+    "TruthSourcePayload",
+]

--- a/tests/integration/test_auto_resolution_api.py
+++ b/tests/integration/test_auto_resolution_api.py
@@ -1,0 +1,111 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.auto_resolution import (  # noqa: E402
+    AutoResolutionAPI,
+    AutoResolutionService,
+    DecisionRule,
+    IdempotencyKeyConflict,
+)
+
+
+def make_api(tmp_path: Path) -> AutoResolutionAPI:
+    audit_path = tmp_path / "audit" / "resolve.log"
+    service = AutoResolutionService(audit_log=audit_path)
+    return AutoResolutionAPI(service), service
+
+
+def test_api_apply_success_flow(tmp_path: Path) -> None:
+    api, service = make_api(tmp_path)
+    payload = {
+        "schema_version": 1,
+        "decision_id": "case-1",
+        "truth_source": "registry",
+        "quorum": True,
+        "payload": {
+            "truth": {"status": "final", "verdict": "yes", "confidence": 0.97},
+            "quorum": {"outcome": "yes", "confidence": 0.82, "contributors": ["alpha", "beta"]},
+            "market_id": "PM:ABC",
+        },
+    }
+
+    response = api.resolve_apply(payload, actor="alice", role="resolver", idempotency_key="k-1")
+
+    assert response["outcome"] == "yes"
+    assert response["rule"] == DecisionRule.TRUTH_SOURCE_FINAL
+
+    entries = service.load_audit_entries()
+    assert len(entries) == 1
+    assert entries[0]["metadata"]["market_id"] == "PM:ABC"
+
+
+def test_api_manual_override(tmp_path: Path) -> None:
+    api, service = make_api(tmp_path)
+    payload = {
+        "schema_version": 1,
+        "decision_id": "case-2",
+        "truth_source": "registry",
+        "quorum": False,
+        "payload": {
+            "truth": {"status": "pending", "confidence": 0.2},
+            "quorum": {"outcome": None},
+            "manual_override": {"outcome": "refund", "reason": "operator"},
+        },
+    }
+
+    response = api.resolve_apply(payload, actor="carol", role="admin", idempotency_key="k-2")
+
+    assert response["outcome"] == "refund"
+    assert response["rule"] == DecisionRule.MANUAL_OVERRIDE
+
+    entries = service.load_audit_entries()
+    assert entries[0]["manual_override"] == "operator"
+
+
+def test_api_idempotency_conflict(tmp_path: Path) -> None:
+    api, _ = make_api(tmp_path)
+    base = {
+        "schema_version": 1,
+        "decision_id": "case-3",
+        "truth_source": "registry",
+        "quorum": True,
+        "payload": {
+            "truth": {"status": "final", "verdict": "yes"},
+            "quorum": {"outcome": "yes"},
+        },
+    }
+    api.resolve_apply(base, actor="alice", role="resolver", idempotency_key="k-shared")
+
+    modified = {
+        **base,
+        "payload": {
+            "truth": {"status": "final", "verdict": "no"},
+            "quorum": {"outcome": "no"},
+        },
+    }
+
+    with pytest.raises(IdempotencyKeyConflict):
+        api.resolve_apply(modified, actor="alice", role="resolver", idempotency_key="k-shared")
+
+
+def test_api_enforces_rbac(tmp_path: Path) -> None:
+    api, _ = make_api(tmp_path)
+    payload = {
+        "schema_version": 1,
+        "decision_id": "case-4",
+        "truth_source": "registry",
+        "quorum": True,
+        "payload": {
+            "truth": {"status": "final", "verdict": "yes"},
+            "quorum": {"outcome": "yes"},
+        },
+    }
+
+    with pytest.raises(PermissionError):
+        api.resolve_apply(payload, actor="mallory", role="viewer", idempotency_key="k-4")

--- a/tests/unit/test_auto_resolution.py
+++ b/tests/unit/test_auto_resolution.py
@@ -1,0 +1,210 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.auto_resolution import (  # noqa: E402
+    AutoResolutionService,
+    DecisionRule,
+    IdempotencyKeyConflict,
+    ManualOverride,
+    QuorumEvaluation,
+    TruthSourcePayload,
+)
+
+
+def make_service(tmp_path: Path) -> AutoResolutionService:
+    audit_path = tmp_path / "audit" / "resolve.log"
+    return AutoResolutionService(audit_log=audit_path)
+
+
+def test_truth_source_final_preferred(tmp_path: Path) -> None:
+    service = make_service(tmp_path)
+    truth = TruthSourcePayload(
+        source="registry",
+        status="final",
+        verdict="yes",
+        confidence=0.98,
+    )
+    quorum = QuorumEvaluation(quorum_ok=True, suggested_outcome="yes", confidence=0.8)
+
+    decision = service.apply_resolution(
+        decision_id="dec-1",
+        truth_payload=truth,
+        quorum_result=quorum,
+        actor="alice",
+        role="resolver",
+        idempotency_key="idem-1",
+    )
+
+    assert decision.outcome == "yes"
+    assert decision.rule == DecisionRule.TRUTH_SOURCE_FINAL
+
+    entries = service.load_audit_entries()
+    assert len(entries) == 1
+    assert entries[0]["outcome"] == "yes"
+    assert entries[0]["truth_verdict"] == "yes"
+
+
+def test_truth_source_override_on_conflict(tmp_path: Path) -> None:
+    service = make_service(tmp_path)
+    truth = TruthSourcePayload(
+        source="registry",
+        status="final",
+        verdict="no",
+        confidence=0.92,
+    )
+    quorum = QuorumEvaluation(quorum_ok=True, suggested_outcome="yes", confidence=0.7)
+
+    decision = service.apply_resolution(
+        decision_id="dec-2",
+        truth_payload=truth,
+        quorum_result=quorum,
+        actor="alice",
+        role="resolver",
+        idempotency_key="idem-2",
+    )
+
+    assert decision.outcome == "no"
+    assert decision.rule == DecisionRule.TRUTH_SOURCE_OVERRIDE
+
+
+def test_quorum_consensus_when_truth_pending(tmp_path: Path) -> None:
+    service = make_service(tmp_path)
+    truth = TruthSourcePayload(
+        source="registry",
+        status="pending",
+        verdict=None,
+        confidence=0.2,
+    )
+    quorum = QuorumEvaluation(quorum_ok=True, suggested_outcome="yes", confidence=0.65)
+
+    decision = service.apply_resolution(
+        decision_id="dec-3",
+        truth_payload=truth,
+        quorum_result=quorum,
+        actor="alice",
+        role="resolver",
+        idempotency_key="idem-3",
+    )
+
+    assert decision.outcome == "yes"
+    assert decision.rule == DecisionRule.QUORUM_CONSENSUS
+
+
+def test_manual_override_supersedes_all(tmp_path: Path) -> None:
+    service = make_service(tmp_path)
+    truth = TruthSourcePayload(
+        source="registry",
+        status="pending",
+        verdict=None,
+        confidence=0.3,
+    )
+    quorum = QuorumEvaluation(quorum_ok=False, suggested_outcome=None)
+
+    decision = service.apply_resolution(
+        decision_id="dec-4",
+        truth_payload=truth,
+        quorum_result=quorum,
+        actor="bob",
+        role="admin",
+        idempotency_key="idem-4",
+        manual_override=ManualOverride(outcome="refund", reason="operator override"),
+    )
+
+    assert decision.outcome == "refund"
+    assert decision.rule == DecisionRule.MANUAL_OVERRIDE
+
+
+def test_idempotency_replay_returns_same_result(tmp_path: Path) -> None:
+    service = make_service(tmp_path)
+    truth = TruthSourcePayload(
+        source="registry",
+        status="final",
+        verdict="yes",
+        confidence=0.99,
+    )
+    quorum = QuorumEvaluation(quorum_ok=True, suggested_outcome="yes", confidence=0.9)
+
+    first = service.apply_resolution(
+        decision_id="dec-5",
+        truth_payload=truth,
+        quorum_result=quorum,
+        actor="carol",
+        role="resolver",
+        idempotency_key="shared",
+    )
+    second = service.apply_resolution(
+        decision_id="dec-5",
+        truth_payload=truth,
+        quorum_result=quorum,
+        actor="carol",
+        role="resolver",
+        idempotency_key="shared",
+    )
+
+    assert first.outcome == second.outcome
+    assert first.trace_id == second.trace_id
+    entries = service.load_audit_entries()
+    assert len(entries) == 1
+
+
+def test_idempotency_conflict_raises(tmp_path: Path) -> None:
+    service = make_service(tmp_path)
+    truth_a = TruthSourcePayload(
+        source="registry",
+        status="final",
+        verdict="yes",
+        confidence=0.7,
+    )
+    truth_b = TruthSourcePayload(
+        source="registry",
+        status="final",
+        verdict="no",
+        confidence=0.7,
+    )
+    quorum = QuorumEvaluation(quorum_ok=True, suggested_outcome="yes")
+
+    service.apply_resolution(
+        decision_id="dec-6",
+        truth_payload=truth_a,
+        quorum_result=quorum,
+        actor="alice",
+        role="resolver",
+        idempotency_key="idem-x",
+    )
+
+    with pytest.raises(IdempotencyKeyConflict):
+        service.apply_resolution(
+            decision_id="dec-6",
+            truth_payload=truth_b,
+            quorum_result=quorum,
+            actor="alice",
+            role="resolver",
+            idempotency_key="idem-x",
+        )
+
+
+def test_unauthorized_role_rejected(tmp_path: Path) -> None:
+    service = make_service(tmp_path)
+    truth = TruthSourcePayload(
+        source="registry",
+        status="final",
+        verdict="yes",
+        confidence=0.9,
+    )
+    quorum = QuorumEvaluation(quorum_ok=True, suggested_outcome="yes")
+
+    with pytest.raises(PermissionError):
+        service.apply_resolution(
+            decision_id="dec-7",
+            truth_payload=truth,
+            quorum_result=quorum,
+            actor="mallory",
+            role="viewer",
+            idempotency_key="idem-viewer",
+        )


### PR DESCRIPTION
## Summary
- add an auto-resolution service that enforces Sprint 5 rules, RBAC, idempotency, and audit logging
- expose the service through an in-process /resolve/apply handler with manual override parsing
- cover quorum scenarios, overrides, and audit persistence with new unit and integration tests

## Testing
- pytest tests/unit/test_auto_resolution.py tests/integration/test_auto_resolution_api.py

------
https://chatgpt.com/codex/tasks/task_e_68fc1ce1aae883308dd37d7789c9ae8a