### PR TITLE
Add dbt staging and mart models for simulation and moderation data

### DIFF
--- a/models/marts/mrt_moderation_events.sql
+++ b/models/marts/mrt_moderation_events.sql
@@ -1,0 +1,22 @@
+{{ config(materialized='table') }}
+
+with events as (
+    select * from {{ ref('stg_moderation_events') }}
+),
+ranked as (
+    select
+        *,
+        row_number() over (partition by symbol order by ts desc) as symbol_event_rank
+    from events
+)
+
+select
+    id,
+    ts,
+    symbol,
+    action,
+    reason,
+    evidence_uri,
+    actor,
+    (symbol_event_rank = 1) as is_latest_event
+from ranked;

--- a/models/marts/mrt_simulation_runs.sql
+++ b/models/marts/mrt_simulation_runs.sql
@@ -1,0 +1,28 @@
+{{ config(materialized='table') }}
+
+with runs as (
+    select * from {{ ref('stg_simulation_runs') }}
+),
+metrics as (
+    select
+        id,
+        scenario,
+        started_at,
+        finished_at,
+        p95_latency_ms,
+        result_path,
+        datediff('second', started_at, finished_at) as runtime_seconds,
+        case when p95_latency_ms <= 800 then 'pass' else 'breach' end as latency_slo_status
+    from runs
+)
+
+select
+    id,
+    scenario,
+    started_at,
+    finished_at,
+    p95_latency_ms,
+    result_path,
+    runtime_seconds,
+    latency_slo_status
+from metrics;

--- a/models/staging/stg_moderation_events.sql
+++ b/models/staging/stg_moderation_events.sql
@@ -1,0 +1,27 @@
+{{ config(materialized='table') }}
+
+with raw_events as (
+    select *
+    from read_csv_auto('seeds/moderation_events.csv', header=True)
+),
+typed_events as (
+    select
+        cast(id as varchar) as id,
+        cast(ts as timestamp) as ts,
+        upper(trim(symbol)) as symbol,
+        lower(trim(action)) as action,
+        trim(reason) as reason,
+        trim(evidence_uri) as evidence_uri,
+        lower(trim(actor)) as actor
+    from raw_events
+)
+
+select
+    id,
+    ts,
+    symbol,
+    action,
+    reason,
+    evidence_uri,
+    actor
+from typed_events;

--- a/models/staging/stg_simulation_runs.sql
+++ b/models/staging/stg_simulation_runs.sql
@@ -1,0 +1,25 @@
+{{ config(materialized='table') }}
+
+with raw_runs as (
+    select *
+    from read_csv_auto('seeds/simulation_runs.csv', header=True)
+),
+typed_runs as (
+    select
+        cast(id as varchar) as id,
+        lower(trim(scenario)) as scenario,
+        cast(started_at as timestamp) as started_at,
+        cast(finished_at as timestamp) as finished_at,
+        cast(p95_latency_ms as integer) as p95_latency_ms,
+        trim(result_path) as result_path
+    from raw_runs
+)
+
+select
+    id,
+    scenario,
+    started_at,
+    finished_at,
+    p95_latency_ms,
+    result_path
+from typed_runs;

--- a/models/tests/stg_moderation_events.yml
+++ b/models/tests/stg_moderation_events.yml
@@ -1,0 +1,30 @@
+version: 2
+models:
+  - name: stg_moderation_events
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: ts
+        tests:
+          - not_null
+      - name: symbol
+        tests:
+          - not_null
+      - name: action
+        tests:
+          - not_null
+          - accepted_values:
+              values: [pause, escalate, resume]
+      - name: reason
+        tests:
+          - not_null
+      - name: evidence_uri
+        tests:
+          - not_null
+      - name: actor
+        tests:
+          - not_null
+          - accepted_values:
+              values: [auto_moderator, human_reviewer]

--- a/models/tests/stg_moderation_events_freshness.sql
+++ b/models/tests/stg_moderation_events_freshness.sql
@@ -1,0 +1,7 @@
+with latest_event as (
+    select max(ts) as max_ts from {{ ref('stg_moderation_events') }}
+)
+select events.*
+from {{ ref('stg_moderation_events') }} events
+cross join latest_event
+where datediff('minute', events.ts, latest_event.max_ts) > 60;

--- a/models/tests/stg_simulation_runs.yml
+++ b/models/tests/stg_simulation_runs.yml
@@ -1,0 +1,25 @@
+version: 2
+models:
+  - name: stg_simulation_runs
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: scenario
+        tests:
+          - not_null
+          - accepted_values:
+              values: [spike, gap, burst]
+      - name: started_at
+        tests:
+          - not_null
+      - name: finished_at
+        tests:
+          - not_null
+      - name: p95_latency_ms
+        tests:
+          - not_null
+      - name: result_path
+        tests:
+          - not_null

--- a/models/tests/stg_simulation_runs_freshness.sql
+++ b/models/tests/stg_simulation_runs_freshness.sql
@@ -1,0 +1,7 @@
+with latest_run as (
+    select max(finished_at) as max_finished_at from {{ ref('stg_simulation_runs') }}
+)
+select runs.*
+from {{ ref('stg_simulation_runs') }} runs
+cross join latest_run
+where datediff('minute', runs.finished_at, latest_run.max_finished_at) > 120;

--- a/seeds/moderation_events.csv
+++ b/seeds/moderation_events.csv
@@ -1,0 +1,4 @@
+id,ts,symbol,action,reason,evidence_uri,actor
+MOD-20240101-0001,2024-01-01 00:10:00,BRLUSD,pause,divergence>1%,s3://moderation/events/MOD-20240101-0001.json,auto_moderator
+MOD-20240101-0002,2024-01-01 00:25:00,BRLUSD,escalate,manual_review_requested,s3://moderation/events/MOD-20240101-0002.json,human_reviewer
+MOD-20240101-0003,2024-01-01 00:45:00,BRLUSD,resume,conditions_restored,s3://moderation/events/MOD-20240101-0003.json,auto_moderator

--- a/seeds/simulation_runs.csv
+++ b/seeds/simulation_runs.csv
@@ -1,0 +1,4 @@
+id,scenario,started_at,finished_at,p95_latency_ms,result_path
+SIM-20240101-0001,spike,2024-01-01 00:00:00,2024-01-01 00:05:00,620,s3://simulations/spike/report.json
+SIM-20240101-0002,gap,2024-01-01 01:30:00,2024-01-01 01:34:30,700,s3://simulations/gap/report.json
+SIM-20240101-0003,burst,2024-01-01 03:00:00,2024-01-01 03:04:15,540,s3://simulations/burst/report.json


### PR DESCRIPTION
## Summary
- add staging models for simulation runs and moderation events backed by csv fixtures
- expose mart layers for simulation and moderation datasets with derived quality metrics
- define schema and freshness tests to enforce contract columns and expected categorical values

## Testing
- `make dbt-ci` *(fails: Makefile target uses spaces instead of tabs in current repo)*
- `pip install 'dbt-duckdb~=1.8.0'` *(fails: network proxy prevents downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68fc1ce3d60083309e84140599753037