### PR TITLE
Add Sprint 5 auto-resolution engine with metrics and auditing

### DIFF
--- a/services/auto_resolution/__init__.py
+++ b/services/auto_resolution/__init__.py
@@ -1,8 +1,11 @@
 """Auto-resolution service package."""
 from .service import (
+    AGREEMENT_THRESHOLD,
     ALLOWED_AUTO_ROLES,
     ALLOWED_MANUAL_ROLES,
+    AutoResolutionMetrics,
     AutoResolutionService,
+    ResolutionConflict,
     ResolutionError,
     ResolutionRecord,
     TruthSourceSignal,
@@ -10,9 +13,12 @@ from .service import (
 from .api import apply_resolution
 
 __all__ = [
+    "AGREEMENT_THRESHOLD",
     "ALLOWED_AUTO_ROLES",
     "ALLOWED_MANUAL_ROLES",
+    "AutoResolutionMetrics",
     "AutoResolutionService",
+    "ResolutionConflict",
     "ResolutionError",
     "ResolutionRecord",
     "TruthSourceSignal",

--- a/services/auto_resolution/api.py
+++ b/services/auto_resolution/api.py
@@ -4,22 +4,35 @@ from __future__ import annotations
 from typing import Any, Dict, Mapping, Optional
 import time
 
-from .service import AutoResolutionService, ResolutionRecord, TruthSourceSignal
+from .service import (
+    AutoResolutionService,
+    ResolutionRecord,
+    TruthSourceSignal,
+)
 
 
 def apply_resolution(payload: Mapping[str, Any], *, service: AutoResolutionService) -> Dict[str, Any]:
     """Process a `/resolve/apply` request using the provided service."""
 
-    required_fields = {"event_id", "quorum_votes", "actor", "role", "idempotency_key"}
+    required_fields = {"event_id", "actor", "role", "idempotency_key"}
     missing = required_fields - payload.keys()
     if missing:
         missing_str = ", ".join(sorted(missing))
         raise ValueError(f"Missing required fields: {missing_str}")
 
+    quorum_input = _resolve_quorum(payload)
     truth_source_signal = _build_truth_source(payload.get("truth_source"))
+
+    resource_version = payload.get("resource_version")
+    resource_version_value: Optional[int]
+    if resource_version is None:
+        resource_version_value = None
+    else:
+        resource_version_value = int(resource_version)
+
     record = service.apply(
         event_id=str(payload["event_id"]),
-        quorum_votes=_normalize_votes(payload.get("quorum_votes", [])),
+        quorum_votes=quorum_input,
         actor=str(payload["actor"]),
         role=str(payload["role"]),
         idempotency_key=str(payload["idempotency_key"]),
@@ -28,14 +41,19 @@ def apply_resolution(payload: Mapping[str, Any], *, service: AutoResolutionServi
         manual_override=payload.get("manual_override"),
         manual_reason=payload.get("manual_reason"),
         evidence_uri=payload.get("evidence_uri"),
+        resource_version=resource_version_value,
     )
     return _format_response(record)
 
 
-def _normalize_votes(votes: Any) -> list[str]:
-    if isinstance(votes, (list, tuple)):
-        return [str(vote) for vote in votes]
-    raise ValueError("quorum_votes must be a sequence of strings")
+def _resolve_quorum(payload: Mapping[str, Any]) -> Any:
+    if "quorum" in payload:
+        return payload["quorum"]
+    if "quorum_votes" in payload:
+        votes = payload["quorum_votes"]
+        if isinstance(votes, (list, tuple)):
+            return [str(vote) for vote in votes]
+    raise ValueError("Request must include `quorum` or `quorum_votes`")
 
 
 def _build_truth_source(data: Optional[Mapping[str, Any]]) -> Optional[TruthSourceSignal]:
@@ -60,6 +78,8 @@ def _format_response(record: ResolutionRecord) -> Dict[str, Any]:
         "quorum_ok": record.quorum_ok,
         "truth_source_used": record.truth_source_used,
         "manual_override": record.manual_override,
+        "resource_version": record.resource_version,
+        "agreement_score": record.agreement_score,
     }
 
 

--- a/services/auto_resolution/service.py
+++ b/services/auto_resolution/service.py
@@ -4,17 +4,28 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict
 from hashlib import sha256
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 import json
 import time
 import uuid
 
-ALLOWED_AUTO_ROLES = {"resolver", "admin", "resolver_lead"}
-ALLOWED_MANUAL_ROLES = {"admin", "resolver_lead"}
+ALLOWED_AUTO_ROLES = {"operator", "admin"}
+ALLOWED_MANUAL_ROLES = {"admin"}
+
+DIVERGENCE_THRESHOLD = 0.01
+AGREEMENT_THRESHOLD = 0.5
 
 
 class ResolutionError(RuntimeError):
     """Raised when a resolution cannot be applied automatically."""
+
+
+class ResolutionConflict(ResolutionError):
+    """Raised when `resource_version` semantics detect a conflict."""
+
+    def __init__(self, message: str, *, resource_version: int) -> None:
+        super().__init__(message)
+        self.resource_version = resource_version
 
 
 @dataclass
@@ -49,6 +60,47 @@ class ResolutionRecord:
     quorum_ok: bool
     truth_source_used: bool
     manual_override: bool
+    resource_version: int
+    agreement_score: float
+
+
+class AutoResolutionMetrics:
+    """Persist metrics/traces for auto-resolution evaluations."""
+
+    def __init__(self, metrics_log: Path) -> None:
+        self.metrics_log = metrics_log
+        self.metrics_log.parent.mkdir(parents=True, exist_ok=True)
+
+    def emit(
+        self,
+        *,
+        status: str,
+        event_id: str,
+        trace_id: str,
+        duration_s: float,
+        outcome: Optional[str] = None,
+        reason: Optional[str] = None,
+        truth_source_used: Optional[bool] = None,
+        manual_override: Optional[bool] = None,
+        agreement_score: Optional[float] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        payload = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "span": "auto_resolve.eval",
+            "status": status,
+            "event_id": event_id,
+            "trace_id": trace_id,
+            "duration_ms": round(duration_s * 1000, 3),
+            "outcome": outcome,
+            "reason": reason,
+            "truth_source_used": truth_source_used,
+            "manual_override": manual_override,
+            "agreement_score": agreement_score,
+            "error": error,
+        }
+        with self.metrics_log.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload) + "\n")
 
 
 class AutoResolutionService:
@@ -58,20 +110,26 @@ class AutoResolutionService:
         self,
         *,
         audit_log: Path,
+        metrics_log: Optional[Path] = None,
         quorum_threshold: float = 2 / 3,
         truth_confidence_threshold: float = 0.7,
+        divergence_threshold: float = DIVERGENCE_THRESHOLD,
     ) -> None:
         self.audit_log = audit_log
         self.audit_log.parent.mkdir(parents=True, exist_ok=True)
+        metrics_path = metrics_log or audit_log.parent / "metrics.jsonl"
+        self.metrics = AutoResolutionMetrics(metrics_path)
         self.quorum_threshold = quorum_threshold
         self.truth_confidence_threshold = truth_confidence_threshold
+        self.divergence_threshold = divergence_threshold
         self._idempotency: Dict[str, ResolutionRecord] = {}
+        self._versions: Dict[str, int] = {}
 
     def apply(
         self,
         *,
         event_id: str,
-        quorum_votes: Sequence[str],
+        quorum_votes: Sequence[Mapping[str, object]] | Mapping[str, object] | Sequence[str],
         actor: str,
         role: str,
         idempotency_key: str,
@@ -80,7 +138,10 @@ class AutoResolutionService:
         manual_override: Optional[str] = None,
         manual_reason: Optional[str] = None,
         evidence_uri: Optional[str] = None,
+        resource_version: Optional[int] = None,
     ) -> ResolutionRecord:
+        start = time.perf_counter()
+        resolved_trace = trace_id or uuid.uuid4().hex
         self._require_idempotency_key(idempotency_key)
         existing = self._idempotency.get(idempotency_key)
         if existing is not None:
@@ -88,22 +149,210 @@ class AutoResolutionService:
                 raise ResolutionError("Idempotency key reuse for different event is not allowed")
             return existing
 
-        normalized_votes = [vote.lower() for vote in quorum_votes]
+        current_version = self._versions.get(event_id, 0)
+        if event_id in self._versions:
+            if resource_version is None:
+                raise ResolutionConflict(
+                    "resource_version required for existing events",
+                    resource_version=current_version,
+                )
+            if resource_version != current_version:
+                raise ResolutionConflict(
+                    "resource_version mismatch",
+                    resource_version=current_version,
+                )
+        else:
+            if resource_version not in (None, 0):
+                raise ResolutionConflict(
+                    "resource_version must be 0 for new events",
+                    resource_version=0,
+                )
+
         self._enforce_role(role, ALLOWED_AUTO_ROLES, action="apply resolution")
 
-        if manual_override is not None:
-            self._enforce_role(role, ALLOWED_MANUAL_ROLES, action="perform manual override")
-            outcome, truth_used, reason = self._apply_manual_override(manual_override, manual_reason)
-            manual_flag = True
-            quorum_ok = self._quorum_reached(normalized_votes)
-        else:
-            manual_flag = False
-            outcome, truth_used, reason, quorum_ok = self._apply_auto_logic(
-                normalized_votes, truth_source
-            )
+        votes, divergence = self._normalize_votes(quorum_votes)
 
+        try:
+            if manual_override is not None:
+                record = self._apply_manual_override(
+                    event_id=event_id,
+                    votes=votes,
+                    manual_override=manual_override,
+                    manual_reason=manual_reason,
+                    evidence_uri=evidence_uri,
+                    resolved_trace=resolved_trace,
+                    idempotency_key=idempotency_key,
+                    role=role,
+                    duration_start=start,
+                    current_version=current_version,
+                )
+            else:
+                record = self._apply_auto_logic(
+                    event_id=event_id,
+                    votes=votes,
+                    divergence=divergence,
+                    truth_source=truth_source,
+                    resolved_trace=resolved_trace,
+                    idempotency_key=idempotency_key,
+                    duration_start=start,
+                    current_version=current_version,
+                )
+        except Exception as exc:  # noqa: BLE001 - propagate after logging metrics
+            duration = time.perf_counter() - start
+            self.metrics.emit(
+                status="error",
+                event_id=event_id,
+                trace_id=resolved_trace,
+                duration_s=duration,
+                error=str(exc),
+            )
+            raise
+
+        self._idempotency[idempotency_key] = record
+        self._versions[event_id] = record.resource_version
+        self._append_audit(
+            actor=actor,
+            role=role,
+            record=record,
+            votes=votes,
+            truth_source=truth_source,
+            manual_reason=manual_reason,
+            evidence_uri=evidence_uri,
+        )
+        return record
+
+    def _apply_manual_override(
+        self,
+        *,
+        event_id: str,
+        votes: Sequence[Mapping[str, object]],
+        manual_override: str,
+        manual_reason: Optional[str],
+        evidence_uri: Optional[str],
+        resolved_trace: str,
+        idempotency_key: str,
+        role: str,
+        duration_start: float,
+        current_version: int,
+    ) -> ResolutionRecord:
+        self._enforce_role(role, ALLOWED_MANUAL_ROLES, action="perform manual override")
+        if not evidence_uri:
+            raise ValueError("Manual override requires evidence_uri")
+
+        normalized = manual_override.lower()
+        if normalized not in {"accepted", "rejected"}:
+            raise ValueError("Manual override must be 'accepted' or 'rejected'")
+
+        reason = manual_reason or "manual_override"
+        record = self._finalize_record(
+            event_id=event_id,
+            outcome=normalized,
+            reason=reason,
+            resolved_trace=resolved_trace,
+            idempotency_key=idempotency_key,
+            quorum_ok=self._quorum_reached(votes),
+            truth_source_used=False,
+            manual_override=True,
+            agreement_score=self._agreement_score(votes, normalized),
+            current_version=current_version,
+        )
+        duration = time.perf_counter() - duration_start
+        self.metrics.emit(
+            status="success",
+            event_id=event_id,
+            trace_id=resolved_trace,
+            duration_s=duration,
+            outcome=record.outcome,
+            reason=record.reason,
+            truth_source_used=record.truth_source_used,
+            manual_override=True,
+            agreement_score=record.agreement_score,
+        )
+        return record
+
+    def _apply_auto_logic(
+        self,
+        *,
+        event_id: str,
+        votes: Sequence[Mapping[str, object]],
+        divergence: Optional[float],
+        truth_source: Optional[TruthSourceSignal],
+        resolved_trace: str,
+        idempotency_key: str,
+        duration_start: float,
+        current_version: int,
+    ) -> ResolutionRecord:
+        if not votes:
+            raise ResolutionError("Quorum votes required for auto resolution")
+
+        quorum_ok = self._quorum_reached(votes)
+        divergence_ok = divergence is None or divergence <= self.divergence_threshold
+        majority_outcome = self._majority_outcome(votes)
+
+        truth_used = False
+        reason = "quorum"
+        agreement = 0.0
+
+        if truth_source and truth_source.confidence >= self.truth_confidence_threshold:
+            agreement = self._agreement_score(votes, truth_source.verdict)
+            truth_rule_ok = agreement >= AGREEMENT_THRESHOLD
+            if truth_rule_ok or not quorum_ok or not divergence_ok:
+                truth_used = True
+                reason = f"truth_source:{truth_source.source}"
+                outcome = truth_source.verdict
+            else:
+                raise ResolutionError(
+                    "Truth source disagrees with quorum; manual review required",
+                )
+        else:
+            if not quorum_ok or not divergence_ok:
+                raise ResolutionError(
+                    "Quorum or divergence conditions not satisfied",
+                )
+            outcome = majority_outcome
+            agreement = self._agreement_score(votes, outcome)
+
+        record = self._finalize_record(
+            event_id=event_id,
+            outcome=outcome,
+            reason=reason,
+            resolved_trace=resolved_trace,
+            idempotency_key=idempotency_key,
+            quorum_ok=quorum_ok and divergence_ok,
+            truth_source_used=truth_used,
+            manual_override=False,
+            agreement_score=agreement,
+            current_version=current_version,
+        )
+        duration = time.perf_counter() - duration_start
+        self.metrics.emit(
+            status="success",
+            event_id=event_id,
+            trace_id=resolved_trace,
+            duration_s=duration,
+            outcome=record.outcome,
+            reason=record.reason,
+            truth_source_used=record.truth_source_used,
+            manual_override=False,
+            agreement_score=record.agreement_score,
+        )
+        return record
+
+    def _finalize_record(
+        self,
+        *,
+        event_id: str,
+        outcome: str,
+        reason: str,
+        resolved_trace: str,
+        idempotency_key: str,
+        quorum_ok: bool,
+        truth_source_used: bool,
+        manual_override: bool,
+        agreement_score: float,
+        current_version: int,
+    ) -> ResolutionRecord:
         decided_at = time.time()
-        resolved_trace = trace_id or uuid.uuid4().hex
         record = ResolutionRecord(
             event_id=event_id,
             outcome=outcome,
@@ -112,47 +361,12 @@ class AutoResolutionService:
             decided_at=decided_at,
             idempotency_key=idempotency_key,
             quorum_ok=quorum_ok,
-            truth_source_used=truth_used,
-            manual_override=manual_flag,
-        )
-        self._idempotency[idempotency_key] = record
-        self._append_audit(
-            actor=actor,
-            role=role,
-            record=record,
-            quorum_votes=normalized_votes,
-            truth_source=truth_source,
-            manual_reason=manual_reason,
-            evidence_uri=evidence_uri,
+            truth_source_used=truth_source_used,
+            manual_override=manual_override,
+            resource_version=current_version + 1,
+            agreement_score=round(agreement_score, 4),
         )
         return record
-
-    def _apply_manual_override(
-        self, manual_override: str, manual_reason: Optional[str]
-    ) -> tuple[str, bool, str]:
-        normalized = manual_override.lower()
-        if normalized not in {"accepted", "rejected"}:
-            raise ValueError("Manual override must be 'accepted' or 'rejected'")
-        reason = manual_reason or "manual_override"
-        return normalized, False, reason
-
-    def _apply_auto_logic(
-        self, quorum_votes: Sequence[str], truth_source: Optional[TruthSourceSignal]
-    ) -> tuple[str, bool, str, bool]:
-        quorum_ok = self._quorum_reached(quorum_votes)
-        majority_accepts = self._majority_accepts(quorum_votes)
-
-        if truth_source and truth_source.confidence >= self.truth_confidence_threshold:
-            return truth_source.verdict, True, f"truth_source:{truth_source.source}", quorum_ok
-
-        if quorum_ok:
-            reason = "quorum"
-            outcome = "accepted" if majority_accepts else "rejected"
-            return outcome, False, reason, quorum_ok
-
-        raise ResolutionError(
-            "Quorum not reached and no reliable truth source or manual override provided"
-        )
 
     def _append_audit(
         self,
@@ -160,22 +374,23 @@ class AutoResolutionService:
         actor: str,
         role: str,
         record: ResolutionRecord,
-        quorum_votes: Sequence[str],
+        votes: Sequence[Mapping[str, object]],
         truth_source: Optional[TruthSourceSignal],
         manual_reason: Optional[str],
         evidence_uri: Optional[str],
     ) -> None:
-        payload = {
+        payload: MutableMapping[str, object] = {
             "event_id": record.event_id,
-            "quorum_votes": list(quorum_votes),
+            "quorum_votes": [dict(vote) for vote in votes],
             "truth_source": asdict(truth_source) if truth_source else None,
             "outcome": record.outcome,
             "reason": record.reason,
             "manual_reason": manual_reason,
             "evidence_uri": evidence_uri,
             "idempotency_key": record.idempotency_key,
+            "resource_version": record.resource_version,
         }
-        payload_hash = sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+        payload_hash = sha256(json.dumps(payload, sort_keys=True, default=str).encode("utf-8")).hexdigest()
         entry = {
             "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(record.decided_at)),
             "actor": actor,
@@ -189,20 +404,71 @@ class AutoResolutionService:
             "manual_override": record.manual_override,
             "truth_source_used": record.truth_source_used,
             "quorum_ok": record.quorum_ok,
+            "resource_version": record.resource_version,
         }
         with self.audit_log.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry) + "\n")
 
-    def _quorum_reached(self, votes: Sequence[str]) -> bool:
-        if not votes:
+    def _normalize_votes(
+        self, quorum_votes: Sequence[Mapping[str, object]] | Mapping[str, object] | Sequence[str]
+    ) -> Tuple[List[Mapping[str, object]], Optional[float]]:
+        divergence: Optional[float] = None
+        votes_list: Sequence[object]
+
+        if isinstance(quorum_votes, Mapping):
+            divergence_raw = quorum_votes.get("divergence_pct")
+            divergence = float(divergence_raw) if divergence_raw is not None else None
+            votes_list = quorum_votes.get("votes", [])  # type: ignore[assignment]
+        else:
+            votes_list = quorum_votes
+
+        normalized: List[Mapping[str, object]] = []
+        for vote in votes_list:
+            if isinstance(vote, str):
+                normalized.append({"source": "unknown", "verdict": vote.lower(), "weight": 1.0})
+            elif isinstance(vote, Mapping):
+                verdict = str(vote.get("verdict", "")).lower()
+                if verdict not in {"accepted", "rejected"}:
+                    raise ValueError("Vote verdict must be 'accepted' or 'rejected'")
+                weight_raw = vote.get("weight", 1.0)
+                try:
+                    weight = float(weight_raw)
+                except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                    raise ValueError("Vote weight must be numeric") from exc
+                normalized.append(
+                    {
+                        "source": vote.get("source", "unknown"),
+                        "verdict": verdict,
+                        "weight": weight if weight > 0 else 0.0,
+                    }
+                )
+            else:
+                raise ValueError("Unsupported vote entry type")
+
+        return normalized, divergence
+
+    def _quorum_reached(self, votes: Sequence[Mapping[str, object]]) -> bool:
+        total_weight = sum(float(vote.get("weight", 0.0)) for vote in votes)
+        if total_weight <= 0:
             return False
-        support = sum(1 for vote in votes if vote == "accepted")
-        ratio = support / len(votes)
+        support = sum(float(vote.get("weight", 0.0)) for vote in votes if vote.get("verdict") == "accepted")
+        ratio = support / total_weight
         return ratio >= self.quorum_threshold
 
-    def _majority_accepts(self, votes: Sequence[str]) -> bool:
-        support = sum(1 for vote in votes if vote == "accepted")
-        return support >= (len(votes) - support)
+    def _majority_outcome(self, votes: Sequence[Mapping[str, object]]) -> str:
+        support = sum(float(vote.get("weight", 0.0)) for vote in votes if vote.get("verdict") == "accepted")
+        total = sum(float(vote.get("weight", 0.0)) for vote in votes)
+        reject_support = total - support
+        return "accepted" if support >= reject_support else "rejected"
+
+    def _agreement_score(self, votes: Sequence[Mapping[str, object]], verdict: str) -> float:
+        total_weight = sum(float(vote.get("weight", 0.0)) for vote in votes)
+        if total_weight <= 0:
+            return 0.0
+        aligned = sum(
+            float(vote.get("weight", 0.0)) for vote in votes if vote.get("verdict") == verdict
+        )
+        return aligned / total_weight
 
     def _enforce_role(self, role: str, allowed: Iterable[str], *, action: str) -> None:
         if role not in allowed:
@@ -218,11 +484,21 @@ class AutoResolutionService:
         with self.audit_log.open("r", encoding="utf-8") as fh:
             return [json.loads(line) for line in fh if line.strip()]
 
+    def load_metrics_entries(self) -> List[Dict[str, object]]:
+        metrics_path = self.metrics.metrics_log
+        if not metrics_path.exists():
+            return []
+        with metrics_path.open("r", encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+
 
 __all__ = [
+    "AGREEMENT_THRESHOLD",
     "ALLOWED_AUTO_ROLES",
     "ALLOWED_MANUAL_ROLES",
+    "AutoResolutionMetrics",
     "AutoResolutionService",
+    "ResolutionConflict",
     "ResolutionError",
     "ResolutionRecord",
     "TruthSourceSignal",

--- a/tests/integration/test_auto_resolution_api.py
+++ b/tests/integration/test_auto_resolution_api.py
@@ -11,24 +11,42 @@ from services.auto_resolution import AutoResolutionService, apply_resolution  # 
 
 
 def _service(tmp_path: Path) -> AutoResolutionService:
-    audit_path = tmp_path / "audit" / "auto_resolve.log"
-    return AutoResolutionService(audit_log=audit_path)
+    base = tmp_path / "out" / "resolve"
+    audit_path = base / "audit.log"
+    metrics_path = base / "metrics.jsonl"
+    return AutoResolutionService(audit_log=audit_path, metrics_log=metrics_path)
+
+
+def _payload(base: dict | None = None) -> dict:
+    payload = {
+        "event_id": "evt-api-1",
+        "quorum": {
+            "votes": [
+                {"source": "alpha", "verdict": "accepted", "weight": 1.0},
+                {"source": "beta", "verdict": "accepted", "weight": 1.0},
+                {"source": "gamma", "verdict": "rejected", "weight": 1.0},
+            ],
+            "divergence_pct": 0.003,
+        },
+        "actor": "zoe",
+        "role": "operator",
+        "idempotency_key": "idem-api-1234",
+        "resource_version": 0,
+    }
+    if base:
+        payload.update(base)
+    return payload
 
 
 def test_apply_resolution_handler_idempotency(tmp_path: Path) -> None:
     service = _service(tmp_path)
-    payload = {
-        "event_id": "evt-api-1",
-        "quorum_votes": ["accepted", "accepted", "rejected"],
-        "actor": "zoe",
-        "role": "resolver",
-        "idempotency_key": "idem-api-1234",
-    }
+    payload = _payload()
 
     first = apply_resolution(payload, service=service)
     assert first["outcome"] == "accepted"
     assert first["decision_id"]
     assert first["truth_source_used"] is False
+    assert first["resource_version"] == 1
 
     second = apply_resolution(payload, service=service)
     assert second == first
@@ -40,15 +58,16 @@ def test_apply_resolution_handler_idempotency(tmp_path: Path) -> None:
 
 def test_apply_resolution_manual_fallback(tmp_path: Path) -> None:
     service = _service(tmp_path)
-    payload = {
-        "event_id": "evt-api-2",
-        "quorum_votes": ["accepted", "rejected"],
-        "actor": "ivy",
-        "role": "admin",
-        "idempotency_key": "idem-api-5678",
-        "manual_override": "rejected",
-        "manual_reason": "insufficient quorum",
-    }
+    payload = _payload(
+        {
+            "event_id": "evt-api-2",
+            "idempotency_key": "idem-api-5678",
+            "manual_override": "rejected",
+            "manual_reason": "insufficient quorum",
+            "evidence_uri": "s3://bucket/proof",
+            "role": "admin",
+        }
+    )
 
     result = apply_resolution(payload, service=service)
     assert result["outcome"] == "rejected"

--- a/tests/unit/auto_resolution/test_service.py
+++ b/tests/unit/auto_resolution/test_service.py
@@ -11,32 +11,52 @@ from services.auto_resolution.service import (  # noqa: E402
     ALLOWED_AUTO_ROLES,
     ALLOWED_MANUAL_ROLES,
     AutoResolutionService,
+    ResolutionConflict,
     ResolutionError,
     TruthSourceSignal,
 )
 
 
 def _service(tmp_path: Path) -> AutoResolutionService:
-    audit_path = tmp_path / "audit" / "auto_resolve.log"
-    return AutoResolutionService(audit_log=audit_path)
+    audit_path = tmp_path / "out" / "resolve" / "audit.log"
+    metrics_path = tmp_path / "out" / "resolve" / "metrics.jsonl"
+    return AutoResolutionService(audit_log=audit_path, metrics_log=metrics_path)
+
+
+def _votes() -> dict:
+    return {
+        "votes": [
+            {"source": "alpha", "verdict": "accepted", "weight": 1.0},
+            {"source": "beta", "verdict": "accepted", "weight": 1.0},
+            {"source": "gamma", "verdict": "rejected", "weight": 1.0},
+        ],
+        "divergence_pct": 0.004,
+    }
 
 
 def test_quorum_resolution_success(tmp_path: Path) -> None:
     service = _service(tmp_path)
     record = service.apply(
         event_id="evt-1",
-        quorum_votes=["accepted", "accepted", "rejected"],
+        quorum_votes=_votes(),
         actor="alice",
-        role=sorted(ALLOWED_AUTO_ROLES)[0],
+        role="operator",
         idempotency_key="idem-123456",
+        resource_version=0,
     )
     assert record.outcome == "accepted"
     assert record.truth_source_used is False
     assert record.quorum_ok is True
+    assert record.resource_version == 1
+    assert record.agreement_score == pytest.approx(0.6667, rel=1e-4)
 
     audit_entries = service.load_audit_entries()
     assert len(audit_entries) == 1
-    assert audit_entries[0]["action"] == "auto_resolve.apply"
+    assert audit_entries[0]["resource_version"] == 1
+
+    metrics_entries = service.load_metrics_entries()
+    assert metrics_entries[0]["span"] == "auto_resolve.eval"
+    assert metrics_entries[0]["status"] == "success"
 
 
 def test_truth_source_override(tmp_path: Path) -> None:
@@ -44,21 +64,29 @@ def test_truth_source_override(tmp_path: Path) -> None:
     truth = TruthSourceSignal(
         source="trusted_feed",
         verdict="rejected",
-        confidence=0.9,
+        confidence=0.92,
         observed_at="2024-05-01T00:00:00Z",
     )
 
     record = service.apply(
         event_id="evt-2",
-        quorum_votes=["accepted", "accepted", "accepted"],
+        quorum_votes={
+            "votes": [
+                {"source": "alpha", "verdict": "accepted", "weight": 1.0},
+                {"source": "beta", "verdict": "rejected", "weight": 1.0},
+                {"source": "gamma", "verdict": "rejected", "weight": 1.0},
+            ],
+            "divergence_pct": 0.02,
+        },
         actor="bob",
-        role="resolver",
+        role="operator",
         idempotency_key="idem-654321",
         truth_source=truth,
+        resource_version=0,
     )
     assert record.outcome == "rejected"
     assert record.truth_source_used is True
-    assert record.quorum_ok is True
+    assert record.quorum_ok is False  # divergence exceeded threshold
 
 
 def test_quorum_failure_requires_manual_or_truth_source(tmp_path: Path) -> None:
@@ -67,66 +95,113 @@ def test_quorum_failure_requires_manual_or_truth_source(tmp_path: Path) -> None:
     with pytest.raises(ResolutionError):
         service.apply(
             event_id="evt-3",
-            quorum_votes=["accepted", "rejected"],
+            quorum_votes={"votes": []},
             actor="carol",
-            role="resolver",
+            role="operator",
             idempotency_key="idem-abcdef",
+            resource_version=0,
         )
 
 
-def test_manual_override_requires_role(tmp_path: Path) -> None:
+def test_manual_override_requires_role_and_evidence(tmp_path: Path) -> None:
     service = _service(tmp_path)
 
     with pytest.raises(PermissionError):
         service.apply(
             event_id="evt-4",
-            quorum_votes=["rejected", "rejected", "accepted"],
+            quorum_votes=_votes(),
             actor="mallory",
-            role="resolver",
+            role="operator",
             idempotency_key="idem-override",
             manual_override="accepted",
+            resource_version=0,
         )
 
-    # Valid manual override by a privileged role
     privileged_role = sorted(ALLOWED_MANUAL_ROLES)[0]
+    with pytest.raises(ValueError):
+        service.apply(
+            event_id="evt-4",
+            quorum_votes=_votes(),
+            actor="dave",
+            role=privileged_role,
+            idempotency_key="idem-override1",
+            manual_override="accepted",
+            manual_reason="committee decision",
+            resource_version=0,
+        )
+
     record = service.apply(
         event_id="evt-4",
-        quorum_votes=["rejected", "rejected", "accepted"],
+        quorum_votes=_votes(),
         actor="dave",
         role=privileged_role,
         idempotency_key="idem-override2",
         manual_override="accepted",
         manual_reason="committee decision",
+        evidence_uri="s3://bucket/proof",
+        resource_version=0,
     )
     assert record.outcome == "accepted"
     assert record.manual_override is True
     assert record.truth_source_used is False
 
 
+def test_conflict_on_stale_resource_version(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    service.apply(
+        event_id="evt-5",
+        quorum_votes=_votes(),
+        actor="erin",
+        role="operator",
+        idempotency_key="idem-unique",
+        resource_version=0,
+    )
+
+    with pytest.raises(ResolutionConflict):
+        service.apply(
+            event_id="evt-5",
+            quorum_votes=_votes(),
+            actor="erin",
+            role="operator",
+            idempotency_key="idem-unique-2",
+            resource_version=0,
+        )
+
+
 def test_idempotency_returns_same_record(tmp_path: Path) -> None:
     service = _service(tmp_path)
     record = service.apply(
-        event_id="evt-5",
-        quorum_votes=["accepted", "accepted", "rejected"],
-        actor="erin",
-        role="resolver",
+        event_id="evt-6",
+        quorum_votes=_votes(),
+        actor="zoe",
+        role="operator",
         idempotency_key="idem-unique",
+        resource_version=0,
     )
 
     repeat = service.apply(
-        event_id="evt-5",
-        quorum_votes=["rejected", "rejected", "rejected"],
-        actor="erin",
-        role="resolver",
+        event_id="evt-6",
+        quorum_votes={
+            "votes": [
+                {"source": "alpha", "verdict": "rejected", "weight": 1.0},
+                {"source": "beta", "verdict": "rejected", "weight": 1.0},
+                {"source": "gamma", "verdict": "rejected", "weight": 1.0},
+            ],
+            "divergence_pct": 0.001,
+        },
+        actor="zoe",
+        role="operator",
         idempotency_key="idem-unique",
+        resource_version=0,
     )
     assert repeat is record
 
     with pytest.raises(ResolutionError):
         service.apply(
-            event_id="evt-other",
-            quorum_votes=["accepted", "accepted", "rejected"],
-            actor="erin",
-            role="resolver",
+            event_id="evt-7",
+            quorum_votes=_votes(),
+            actor="zoe",
+            role="operator",
             idempotency_key="idem-unique",
+            resource_version=0,
         )


### PR DESCRIPTION
## Summary
- implement Sprint 5 auto-resolution logic with quorum scoring, truth-source overrides, manual fallback enforcement, and conflict-aware audit logging
- expose the resolver through the `/resolve/apply` handler with resource versioning, agreement scores, and RBAC-aligned payload validation
- add resolver metrics emission plus targeted unit and integration tests covering quorum success, overrides, conflicts, and audit persistence

## Testing
- pytest tests/unit/auto_resolution/test_service.py tests/integration/test_auto_resolution_api.py

------
https://chatgpt.com/codex/tasks/task_e_68fc1e13f89483308b656104d83ac2ac