### PR TITLE
Add incident runbooks for oracle, fee, and moderation flows

### DIFF
--- a/analytics/dbt/models/mbp/README.md
+++ b/analytics/dbt/models/mbp/README.md
@@ -24,5 +24,5 @@ raw.mbp_abuse_events -> stg.mbp_abuse_events -> mbp_abuse_events
 - Regras A106/A87/A89 incorporadas via constraints de status/TWAP.
 
 ## Documentação Complementar
-- Runbooks: `docs/runbooks/dec_slo.md`, `docs/runbooks/cdc_lag.md`, `docs/runbooks/schema-drift.md`, `docs/runbooks/rollback-degrade.md`.
+- Runbooks: `docs/runbooks/dec_slo.md`, `docs/runbooks/cdc_lag.md`, `docs/runbooks/schema-drift.md`, `docs/runbooks/rollback-degrade.md`, `docs/runbooks/oracle-quorum-twap.md`, `docs/runbooks/fee-cooldown.md`, `docs/runbooks/moderation-pause.md`.
 - ADRs: `docs/ADRs/ADR-001-DEC-Decision-Engine.md`, `docs/ADRs/ADR-002-Rule-Engine-Resolution.md`, `docs/ADRs/ADR-003-TWAP-Benchmarks.md`.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,14 @@
+# Runbooks do MBP
+
+| Área | Incidente | Arquivo |
+| --- | --- | --- |
+| DEC | Degrade / rollback | [`rollback-degrade.md`](rollback-degrade.md) |
+| DEC | SLO 800 ms | [`dec_slo.md`](dec_slo.md) |
+| Dados | CDC lag > 120 s | [`cdc_lag.md`](cdc_lag.md) |
+| Dados | Schema drift | [`schema-drift.md`](schema-drift.md) |
+| Dados | Decision gap | [`decision_gap.md`](decision_gap.md) |
+| Oráculos | Quorum/TWAP failover | [`oracle-quorum-twap.md`](oracle-quorum-twap.md) |
+| Fees | Thrash / cooldown | [`fee-cooldown.md`](fee-cooldown.md) |
+| Moderação | Pausa / appeals | [`moderation-pause.md`](moderation-pause.md) |
+
+> Consulte `ops/watchers.yml` para mapear cada hook ao runbook correspondente.

--- a/docs/runbooks/fee-cooldown.md
+++ b/docs/runbooks/fee-cooldown.md
@@ -1,0 +1,39 @@
+# Runbook — Fee Thrash / Cooldown Breach
+
+## Objetivo
+Impedir variação de fee > 20% por 5 minutos e restaurar `mbp:fee:delta_pct_5m ≤ 0.20`, `mbp:fee:in_bounds ≥ 0.99` e `mbp:fee:cooldown_hits = 0` em até 30 minutos após o alerta `fee_cooldown_breach`. O incidente afeta a estabilidade de PnL/LPs e pode disparar halts automáticos.
+
+## Detectar
+1. Validar alerta `fee_cooldown_breach` (hook ou PD). Abra o dashboard "S5 MBP Scale" e revise os painéis **"Fee Δ5m"** e **"Fee Cooldown Hits"**.
+2. Consulte as séries canônicas via PromQL (salve o resultado para evidência):
+   ```promql
+   mbp:fee:delta_pct_5m{env="prod"}
+   mbp:fee:in_bounds{env="prod"}
+   mbp:fee:cooldown_hits{env="prod"}
+   ```
+3. Execute `kubectl logs deploy/fee-engine -n mbp --since=10m | rg -i 'cooldown|delta_pct|clamped'` para localizar a origem.
+4. Correlacione traces `fee.update` no Tempo/Jaeger para confirmar se o cooldown foi ignorado por bursts de volume.
+
+## Diagnóstico
+1. **Integridade dos parâmetros** — Capture os limites vigentes `fees.*` via `bash scripts/policy_engine.sh --emit-policy-hash --out out/obs_gatecheck/evidence` e valide `fees.cooldown_ms`, `fees.delta_bound`.
+2. **Volume / Profundidade** — Gere relatório determinístico com `python tools/sim_harness.py --fixtures seeds/s3 --scenario burst --out out/obs_gatecheck/evidence/fee_sim_burst.json` para observar `quorum_ratio`, `divergence_max` e impacto em fees.
+3. **Auditoria** — Verifique `out/obs_gatecheck/logs/fee_engine.log` (ou Loki `label=service:fee-engine`) para entradas `reason=cooldown_active` ausentes.
+4. **Dependências** — Se `depth` estiver anômala, consulte o runbook de liquidez/market maker e confirme se não há correlato com `cdc_lag` ou `oracle`.
+
+## Mitigar
+1. **Aplicar cooldown rígido** — `policy_engine.sh set fees.cooldown_ms=600000` (10 min) e `policy_engine.sh set fees.delta_bound=0.15` temporariamente.
+2. **Suavizar input** — Habilite modo de amortecimento `policy_engine.sh set fees.mode=damped` quando disponível. Enquanto isso, injete média móvel via `kubectl exec deploy/fee-engine -- env FEE_SMOOTHING=ewma_5m`.
+3. **Recalibrar base** — Atualize `configs/policies/mbp_s3.yml` com novo `f0`/`bounds` se o excesso for estrutural; submeta PR emergencial.
+4. **Retorno** — Quando `mbp:fee:delta_pct_5m ≤ 0.15` por 3 janelas consecutivas e `mbp:fee:cooldown_hits` zerado por 30 min, reverta ajustes (`policy_engine.sh set fees.cooldown_ms=300000`, `fees.delta_bound=0.20`).
+5. **Pós-ação** — Consolidar `out/obs_gatecheck/evidence/fees_report.json` com before/after de `mbp:fee:*` (`promtool query range …`) e resumo de ajustes aplicados.
+
+## Evidência ORR
+- Exportar as queries PromQL para `out/obs_gatecheck/evidence/fee_cooldown_metrics.json`.
+- Anexar `fee_sim_burst.json` com delta pós-ajuste ≤ 0.15.
+- Incluir log/screenshot do painel `Fee Δ5m` após normalização em `out/obs_gatecheck/evidence/fee_dashboard.png`.
+- Atualizar `out/obs_gatecheck/logs/fee_runbook.txt` com timestamps, toggles e hash de política.
+
+## Comunicação & Escalonamento
+- Comunicar status inicial no Slack `#dec-incident`; incluir `#finance-ops` se impacto > 15 min.
+- PagerDuty: acionar `pm-dec` se for preciso alterar parâmetros permanentes.
+- Se `mbp:fee:in_bounds < 0.95` por 1h ou houver três incidentes em 7 dias, abrir ação corretiva com `risk@trendmarketv2.dev` e registrar CAPA.

--- a/docs/runbooks/moderation-pause.md
+++ b/docs/runbooks/moderation-pause.md
@@ -1,0 +1,71 @@
+# Runbook — Moderação: Pause / Appeals
+
+## Objetivo
+Garantir `mbp:moderation:pauses_total` controlado, `mbp:moderation:mttd_minutes ≤ 5` e `mbp:moderation:mttm_minutes ≤ 15`, restaurando mercados pausados somente quando segurança e quorum estiverem OK. O gatilho vem de `abuse_spike`, `moderation_pause` ou solicitações de appeals em massa.
+
+## Detectar
+1. Confirmar alerta no Slack (`#compliance` ou `#dec-incident`) e no PagerDuty (`moderation-oncall`).
+2. Abrir o dashboard "S5 MBP Scale" e revisar os painéis **"Moderation Appeals Open"** e `Oracle Staleness` (para contexto).
+3. Rodar as queries PromQL (salvar saída):
+   ```promql
+   mbp:moderation:pauses_total{env="prod"}
+   mbp:moderation:appeals_open{env="prod"}
+   mbp:moderation:mttd_minutes{env="prod"}
+   ```
+4. Validar se há correlação com `abuse.events.rate` ou `mbp:oracle:divergence_p95` (incidentes oráculo podem disparar pausas).
+
+## Diagnóstico
+1. **Estado atual** — Executar `kubectl exec deploy/moderation-service -n mbp -- cat /var/log/moderation/moderation.log | tail -n 50` para recuperar audit trail (hash, actor, outcome).
+2. **Fluxo Appeals** — Gerar relatório com `python - <<'PY' ... PY` lendo `moderation.log` e emitindo `out/obs_gatecheck/evidence/moderation_ops_report.json` (calcule MTTD/MTTM e contagem de appeals) para confirmar SLA.
+   ```bash
+   python - <<'PY'
+   import calendar, json, statistics, time
+   from pathlib import Path
+
+   log = Path('/var/log/moderation/moderation.log')
+   out = Path('out/obs_gatecheck/evidence/moderation_ops_report.json')
+   records = []
+   if log.exists():
+       for line in log.read_text().splitlines():
+           if line.strip():
+               records.append(json.loads(line))
+   pauses = [r for r in records if r['action'] == 'pause']
+   appeals = [r for r in records if r['action'] == 'appeal']
+   mttr = []
+   for pause in pauses:
+       resumed = next((r for r in records if r['action'] == 'resume' and r['target'] == pause['target'] and r['ts'] >= pause['ts']), None)
+       if resumed:
+           mttr.append((time.strptime(resumed['ts'], '%Y-%m-%dT%H:%M:%SZ'), time.strptime(pause['ts'], '%Y-%m-%dT%H:%M:%SZ')))
+   now = time.time()
+   report = {
+       'pauses_total': len(pauses),
+       'appeals_open': len(appeals),
+       'mttd_minutes': statistics.mean([(now - calendar.timegm(time.strptime(p['ts'], '%Y-%m-%dT%H:%M:%SZ'))) / 60 for p in pauses]) if pauses else 0,
+       'mttr_minutes': statistics.mean([(calendar.timegm(end) - calendar.timegm(start)) / 60 for end, start in mttr]) if mttr else 0,
+   }
+   out.parent.mkdir(parents=True, exist_ok=True)
+   out.write_text(json.dumps(report, indent=2))
+   print(f'[moderation_report] saved {out}')
+   PY
+   ```
+3. **Integração Oráculos** — Caso o motivo seja divergência, verificar runbook `docs/runbooks/oracle-quorum-twap.md` antes de reabrir mercado.
+4. **Auto-resolve** — `kubectl logs deploy/auto-resolution -n mbp --since=15m | rg -i 'moderation|appeal'` para ver decisões automáticas.
+5. **Backlog** — Listar appeals pendentes via API (`curl -s -H "Authorization: Bearer $TOKEN" https://api.trendmarketv2.dev/moderation/appeals`).
+
+## Mitigar
+1. **Pause manual** — Se necessário, reforçar pausa: `curl -XPOST https://api.trendmarketv2.dev/moderation/pause -d '{"symbol":"BRLUSD","reason":"oracle_divergence"}'` (actor `moderator`). Registrar `trace_id`.
+2. **Apelações** — Priorizar appeals críticos (`severity=blocker`). Notificar `pm.dec` quando o backlog > 5. Use `services/moderation/service.py` para importar log offline se API indisponível.
+3. **Reabertura** — Quando o motivo original estiver mitigado e `mbp:moderation:appeals_open ≤ 1`, executar `curl -XPOST .../moderation/resume` e confirmar `trace_id` no log.
+4. **Comunicação** — Atualizar canal público/status page com motivo, escopo, ETA e passos de mitigação.
+5. **Prevenção** — Se a causa foi abuso, acionar equipe SEC para recalibrar regras (`auto_resolution/policies`). Para falhas de oráculo, alinhar com runbook de quorum.
+
+## Evidência ORR
+- Persistir as consultas PromQL em `out/obs_gatecheck/evidence/moderation_metrics.json`.
+- Exportar últimos 20 eventos do log para `out/obs_gatecheck/logs/moderation_audit_tail.json` (usar `jq` para estruturar).
+- Anexar captura da fila de appeals pós-normalização (`out/obs_gatecheck/evidence/moderation_dashboard.png`).
+- Atualizar `out/obs_gatecheck/evidence/moderation_ops_report.json` com MTTD/MTTM reais e decisões tomadas.
+
+## Comunicação & Escalonamento
+- Reportar início/fim no Slack `#compliance` e `#dec-incident`.
+- PagerDuty: escalar para `legal-oncall` se `appeals_open > 10` por mais de 30 min ou se houver impacto regulatório.
+- Registrar ticket `CAPA-MOD` em até 24h com causas, métricas e links para evidências.

--- a/docs/runbooks/oracle-quorum-twap.md
+++ b/docs/runbooks/oracle-quorum-twap.md
@@ -1,0 +1,46 @@
+# Runbook — Oráculos: Quorum / TWAP Failover
+
+## Objetivo
+Restabelecer quorum ≥ 2/3 e manter `mbp:oracle:staleness_p95_ms ≤ 30000`, `mbp:oracle:divergence_p95 ≤ 0.01` e `mbp:oracle:failover_time_p95_s < 60` em até 15 minutos após o gatilho. O alerta chega pelos hooks `oracle_staleness_guard` ou `twap_divergence` (freeze automático) e compromete o SLA de preços do MBP.
+
+## Detectar
+1. Validar o alerta no Grafana (`dashboard "S5 MBP Scale"`). Revise os painéis **"Oracle Staleness p95 (ms)"** e **"Oracle Divergence p95"** para confirmar a regressão.
+2. Execute as consultas PromQL para confirmar a severidade:
+   ```promql
+   mbp:oracle:staleness_p95_ms{symbol="BRLUSD"}
+   mbp:oracle:divergence_p95{symbol="BRLUSD"}
+   mbp:oracle:quorum_ratio
+   mbp:oracle:failover_time_p95_s
+   ```
+   Use `promtool query instant http://prometheus:9090 '…' --time=$(date -u +%s)` para arquivar o resultado.
+3. Cheque logs recentes do agregador `oracle-gateway` (`kubectl logs deploy/oracle-gateway -n mbp --since=15m | rg -i 'quorum|stale|failover'`).
+4. Se o freeze ocorreu por `twap_divergence`, confirme eventos `twap_recomputed` e `freeze` via `tempo`/`jaeger` filtrando por `trace.service=dec-engine` e `span.name=twap.compute`.
+
+## Diagnóstico
+1. **Saúde das fontes** — Liste batidas de heartbeat por feed (`kubectl exec statefulset/oracle-feed -- curl -s localhost:8080/healthz`). Verifique `quality_score` e `staleness`.
+2. **Quorum real** — Rode `python tools/sim_harness.py --fixtures seeds/s3 --scenario spike --out out/obs_gatecheck/evidence/oracle_sim_spike.json` para comparar quorum e TWAP com amostras determinísticas.
+3. **Configuração atual** — Capture toggles ativos via `bash scripts/policy_engine.sh --emit-policy-hash --out out/obs_gatecheck/evidence` e valide se `enable_twap_failover` e `enable_quorum` estão `true`.
+4. **Causa raiz provável** —
+   - Divergência alta persistente → fonte enviesada (verificar `services/oracles/aggregator.py`).
+   - Staleness elevado → atraso na ingestão (`CDC`, upstream HTTP, fila). Cruze com runbook `docs/runbooks/cdc_lag.md` se necessário.
+   - Quorum < 2/3 → feeds indisponíveis; revisar circuit-breakers (`ops/watchers/a110_observability.yaml`).
+
+## Mitigar
+1. **Failover imediato** — `policy_engine.sh set enable_twap_failover=true` (mantém TWAP de 60s servido). Verifique `mbp:oracle:failover_time_p95_s` < 60 após 2 janelas.
+2. **Rebalancear quorum** — Atualize os pesos no ConfigMap `oracle-quorum` (`kubectl edit configmap/oracle-quorum -n mbp`) garantindo pelo menos duas fontes `weight ≥ 0.3`. Registre valores aplicados.
+3. **Sanear feeds** —
+   - Banir feed degradado: `policy_engine.sh set oracle.feed.<id>.enabled=false`.
+   - Forçar refresh (`kubectl exec` feed afetado → `curl -XPOST /refresh`).
+4. **Retorno gradual** — Quando `mbp:oracle:quorum_ratio ≥ 0.66` e `mbp:oracle:staleness_p95_ms ≤ 15000` por 3 janelas, reverta reweights, reabilite feeds e desative failover (`policy_engine.sh set enable_twap_failover=false`).
+5. **Preventivo** — Abrir tarefa para ajustar limites (`configs/policies/mbp_s3.yml`) se o incidente demandou alteração permanente.
+
+## Evidência ORR
+- Exportar as queries PromQL acima para `out/obs_gatecheck/evidence/oracle_quorum_metrics.json` (JSON line).
+- Anexar `out/obs_gatecheck/evidence/oracle_sim_spike.json` do `tools/sim_harness.py` com `quorum_ratio` pós-correção ≥ 0.66.
+- Capturar screenshot do painel Grafana pós-recuperação e arquivar em `out/obs_gatecheck/evidence/oracle_dashboard.png`.
+- Atualizar `out/obs_gatecheck/logs/oracle_failover.txt` com comandos executados e hashes de políticas (`policy_hash.txt`).
+
+## Comunicação & Escalonamento
+- Anunciar status inicial e atualizações no Slack `#dec-incident`; abrir incidente `INC-ORACLE` com timeline e métricas anexadas.
+- PagerDuty: acionar `sre-primary`. Notificar `pm.dec@trendmarketv2.dev` quando failover for ativado > 10 min.
+- Se o quorum não recuperar em 30 min ou houver segunda ocorrência em <24 h, escalar para `compliance@trendmarketv2.dev` e iniciar revisão de provedores.

--- a/ops/watchers.yml
+++ b/ops/watchers.yml
@@ -52,7 +52,15 @@ watchers:
     threshold: "> 1.0% (2 janelas)"
     action: freeze
     owner: product_dec
-    runbook: docs/runbooks/cdc_lag.md
+    runbook: docs/runbooks/oracle-quorum-twap.md
+    notify:
+      slack: "#dec-incident"
+  - hook: fee_cooldown_breach
+    metric: mbp:fee:delta_pct_5m
+    threshold: "> 0.20 (5m) ou cooldown_hits>0"
+    action: enforce_cooldown
+    owner: product_dec
+    runbook: docs/runbooks/fee-cooldown.md
     notify:
       slack: "#dec-incident"
   - hook: abuse_spike
@@ -60,6 +68,6 @@ watchers:
     threshold: "> baseline +3σ"
     action: escalate
     owner: compliance
-    runbook: docs/runbooks/decision_gap.md
+    runbook: docs/runbooks/moderation-pause.md
     notify:
       slack: "#compliance"


### PR DESCRIPTION
## Summary
- add runbooks covering oracle quorum/TWAP failover, fee cooldown breaches, and moderation pause/appeal handling with diagnostics, mitigation, and ORR evidence checklists
- register the new playbooks in the runbook index, dbt documentation, and watcher catalog so on-call teams can discover them alongside existing procedures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc1e209b74833083d54da514ac568a