### PR TITLE
Ensure dbt-ci creates DuckDB output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,41 +8,42 @@ BUNDLE_DIR := out
 .PHONY: prega env.pin orr bundle anchors flame micro dbt.docs rum.docs nb.perf clean
 
 prega: env.pin orr bundle anchors nb.perf
-@echo "[prega] pipeline concluída"
+	@echo "[prega] pipeline concluída"
 
 env.pin:
-@set -euo pipefail; ./scripts/env_pin_check.sh
+	@set -euo pipefail; ./scripts/env_pin_check.sh
 
 orr:
-@set -euo pipefail; ./scripts/orr_s4_run.sh
+	@set -euo pipefail; ./scripts/orr_s4_run.sh
 
 bundle:
-@set -euo pipefail; ./scripts/s4_bundle.sh
+	@set -euo pipefail; ./scripts/s4_bundle.sh
 
 anchors:
-@set -euo pipefail; ./scripts/anchor_integrity.sh
+	@set -euo pipefail; ./scripts/anchor_integrity.sh
 
 flame:
-@set -euo pipefail; ./scripts/flamegraph_hotpaths.sh
+	@set -euo pipefail; ./scripts/flamegraph_hotpaths.sh
 
 micro:
-@set -euo pipefail; ./scripts/microbench_dec.sh
+	@set -euo pipefail; ./scripts/microbench_dec.sh
 
 dbt.docs:
-@set -euo pipefail; dbt docs generate --project-dir analytics/dbt --profiles-dir analytics/dbt/profiles
+	@set -euo pipefail; dbt docs generate --project-dir analytics/dbt --profiles-dir analytics/dbt/profiles
 
 rum.docs:
-@set -euo pipefail; node fe/rum/collector_publish.js
+	@set -euo pipefail; node fe/rum/collector_publish.js
 
 nb.perf:
-@set -euo pipefail; python3 scripts/nb_perf_export.py
+	@set -euo pipefail; python3 scripts/nb_perf_export.py
 
 clean:
-rm -rf $(OUT_DIR) out/s4_evidence_bundle_*.zip out/s4_evidence_bundle_*.zip.sha256 || true
+	rm -rf $(OUT_DIR) out/s4_evidence_bundle_*.zip out/s4_evidence_bundle_*.zip.sha256 || true
 
 .PHONY: dbt-ci sim-all orr-bundle
 
 dbt-ci:
+	mkdir -p out/dbt/tmp
 	pip install 'dbt-duckdb~=1.8.0'
 	dbt deps --profiles-dir ~/.dbt --profile ce_profile
 	dbt debug --profiles-dir ~/.dbt --profile ce_profile

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: ce_dbt
 version: 1.0.0
 profile: ce_profile
 model-paths: ["models"]
-tests-paths: ['tests', 'models/tests']
+test-paths: ['tests', 'models/tests']
 seed-paths: ["seeds"]
 models:
   ce_dbt:


### PR DESCRIPTION
## Summary
- ensure the dbt-ci target creates the out/dbt/tmp directory before running dbt commands so the DuckDB file path exists

## Testing
- make dbt-ci *(fails: pip cannot reach the proxy to download dbt-duckdb even though it is already installed)*

------
https://chatgpt.com/codex/tasks/task_e_68fc36caf5ac83309011e959a1b4b792