### PR TITLE
Fix duplicate dbt test definition for mrt_moderation_events

### DIFF
--- a/models/tests/mrt_moderation_events.yml
+++ b/models/tests/mrt_moderation_events.yml
@@ -19,9 +19,6 @@ models:
       - name: ts
         tests:
           - not_null
-      - name: symbol
-        tests:
-          - not_null
       - name: action
         tests:
           - not_null


### PR DESCRIPTION
## Summary
- remove the duplicate `symbol` column test definition from the `mrt_moderation_events` dbt schema to avoid name collisions during compilation

## Testing
- dbt run --profiles-dir ~/.dbt --profile ce_profile *(fails: `dbt` command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc3caca14c8330b0ba9400c8502156