### PR TITLE
Fix staging SQL syntax for Sprint 5 dbt pipeline

### DIFF
--- a/models/staging/stg_moderation_events.sql
+++ b/models/staging/stg_moderation_events.sql
@@ -1,8 +1,5 @@
 {{ config(materialized='table') }}
 
-with raw_events as (
-    select *
-    from read_csv_auto('seeds/moderation_events.csv', header=True)
 with source_data as (
     select *
     from {{ ref('moderation_events') }}
@@ -16,7 +13,6 @@ typed_events as (
         trim(reason) as reason,
         trim(evidence_uri) as evidence_uri,
         lower(trim(actor)) as actor
-    from raw_events
     from source_data
 ),
 ranked_events as (

--- a/models/staging/stg_oracle_quotes.sql
+++ b/models/staging/stg_oracle_quotes.sql
@@ -15,5 +15,4 @@ select
     source,
     price,
     staleness_ms
-from quotes;
-
+from quotes

--- a/models/staging/stg_simulation_runs.sql
+++ b/models/staging/stg_simulation_runs.sql
@@ -1,34 +1,23 @@
 {{ config(materialized='table') }}
 
-with raw_runs as (
-    select *
-    from read_csv_auto('seeds/simulation_runs.csv', header=True)
 with source_data as (
     select *
     from {{ ref('simulation_runs') }}
 ),
 typed_runs as (
     select
-        cast(id as varchar) as id,
+        cast(id as varchar) as run_id,
         lower(trim(scenario)) as scenario,
         cast(started_at as timestamp) as started_at,
         cast(finished_at as timestamp) as finished_at,
         cast(p95_latency_ms as integer) as p95_latency_ms,
         trim(result_path) as result_path
-    from raw_runs
-),
-enriched_runs as (
     from source_data
 ),
 finalized_runs as (
     select
-        id as run_id,
-        id,
+        run_id,
         scenario,
-        case
-            when p95_latency_ms <= 750 then 'success'
-            else 'failed'
-        end as status,
         case when p95_latency_ms <= 750 then 'success' else 'failed' end as status,
         started_at,
         finished_at,
@@ -39,5 +28,4 @@ finalized_runs as (
 )
 
 select *
-from enriched_runs
 from finalized_runs


### PR DESCRIPTION
## Summary
- rewrite the staging models to rely on the seeded tables instead of inline CSV readers
- normalize the moderation and simulation staging outputs to provide the expected columns
- remove the trailing semicolon from the oracle quotes staging model so it parses under dbt

## Testing
- make dbt-ci *(fails: pip cannot reach dbt-duckdb index from container)*

------
https://chatgpt.com/codex/tasks/task_e_68fc48fd93508330871acfe7bf71c9b0