### PR TITLE
Load staging models directly from CSV seeds

### DIFF
--- a/models/marts/mrt_twap_5m.sql
+++ b/models/marts/mrt_twap_5m.sql
@@ -18,5 +18,4 @@ select
     window_start as ts,
     avg_price as twap,
     (quorum_ok = 1) as quorum_ok
-from minute_buckets;
-
+from minute_buckets

--- a/models/staging/stg_moderation_events.sql
+++ b/models/staging/stg_moderation_events.sql
@@ -3,9 +3,6 @@
 with raw_events as (
     select *
     from read_csv_auto('seeds/moderation_events.csv', header=True)
-with source_data as (
-    select *
-    from {{ ref('moderation_events') }}
 ),
 typed_events as (
     select
@@ -17,7 +14,6 @@ typed_events as (
         trim(evidence_uri) as evidence_uri,
         lower(trim(actor)) as actor
     from raw_events
-    from source_data
 ),
 ranked_events as (
     select

--- a/models/staging/stg_oracle_quotes.sql
+++ b/models/staging/stg_oracle_quotes.sql
@@ -15,5 +15,4 @@ select
     source,
     price,
     staleness_ms
-from quotes;
-
+from quotes

--- a/models/staging/stg_simulation_runs.sql
+++ b/models/staging/stg_simulation_runs.sql
@@ -3,13 +3,10 @@
 with raw_runs as (
     select *
     from read_csv_auto('seeds/simulation_runs.csv', header=True)
-with source_data as (
-    select *
-    from {{ ref('simulation_runs') }}
 ),
 typed_runs as (
     select
-        cast(id as varchar) as id,
+        cast(id as varchar) as run_id,
         lower(trim(scenario)) as scenario,
         cast(started_at as timestamp) as started_at,
         cast(finished_at as timestamp) as finished_at,
@@ -17,18 +14,10 @@ typed_runs as (
         trim(result_path) as result_path
     from raw_runs
 ),
-enriched_runs as (
-    from source_data
-),
 finalized_runs as (
     select
-        id as run_id,
-        id,
+        run_id,
         scenario,
-        case
-            when p95_latency_ms <= 750 then 'success'
-            else 'failed'
-        end as status,
         case when p95_latency_ms <= 750 then 'success' else 'failed' end as status,
         started_at,
         finished_at,
@@ -39,5 +28,4 @@ finalized_runs as (
 )
 
 select *
-from enriched_runs
 from finalized_runs


### PR DESCRIPTION
## Summary
- read the moderation and simulation staging inputs straight from the checked-in CSVs and keep the normalization logic intact
- leave the TWAP mart query without a trailing semicolon so duckdb's parser accepts it

## Testing
- make dbt-ci *(fails: pip cannot reach dbt-duckdb index from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc48fd93508330871acfe7bf71c9b0