### PR TITLE
Fix dbt test definitions for Sprint 5 validation

### DIFF
--- a/models/tests/stg_simulation_runs.yml
+++ b/models/tests/stg_simulation_runs.yml
@@ -6,9 +6,6 @@ models:
         tests:
           - not_null
           - unique
-      - name: id
-        tests:
-          - not_null
       - name: scenario
         tests:
           - accepted_values:

--- a/tests/dbt/freshness/mrt_moderation_events_freshness.sql
+++ b/tests/dbt/freshness/mrt_moderation_events_freshness.sql
@@ -1,3 +1,3 @@
 select *
 from {{ ref('mrt_moderation_events') }}
-where ts < timestamp '2024-02-25 00:00:00';
+where ts < timestamp '2024-02-25 00:00:00'

--- a/tests/dbt/freshness/mrt_simulation_runs_freshness.sql
+++ b/tests/dbt/freshness/mrt_simulation_runs_freshness.sql
@@ -1,3 +1,3 @@
 select *
 from {{ ref('mrt_simulation_runs') }}
-where hours_since_last_run > 200;
+where hours_since_last_run > 200

--- a/tests/dbt/freshness/mrt_twap_5m_freshness.sql
+++ b/tests/dbt/freshness/mrt_twap_5m_freshness.sql
@@ -4,5 +4,5 @@ with latest_quote as (
 select twap.*
 from {{ ref('mrt_twap_5m') }} twap
 cross join latest_quote
-where datediff('second', twap.ts, latest_quote.max_ts) > 300;
+where datediff('second', twap.ts, latest_quote.max_ts) > 300
 

--- a/tests/dbt/freshness/stg_moderation_events_freshness.sql
+++ b/tests/dbt/freshness/stg_moderation_events_freshness.sql
@@ -4,7 +4,7 @@ with latest_event as (
 select events.*
 from {{ ref('stg_moderation_events') }} events
 cross join latest_event
-where datediff('minute', events.ts, latest_event.max_ts) > 60;
+where datediff('minute', events.ts, latest_event.max_ts) > 60
 select *
 from {{ ref('stg_moderation_events') }}
-where ts < timestamp '2024-02-25 00:00:00';
+where ts < timestamp '2024-02-25 00:00:00'

--- a/tests/dbt/freshness/stg_oracle_quotes_freshness.sql
+++ b/tests/dbt/freshness/stg_oracle_quotes_freshness.sql
@@ -1,4 +1,4 @@
 select *
 from {{ ref('stg_oracle_quotes') }}
-where staleness_ms > 30000;
+where staleness_ms > 30000
 

--- a/tests/dbt/freshness/stg_simulation_runs_freshness.sql
+++ b/tests/dbt/freshness/stg_simulation_runs_freshness.sql
@@ -4,7 +4,7 @@ with latest_run as (
 select runs.*
 from {{ ref('stg_simulation_runs') }} runs
 cross join latest_run
-where datediff('minute', runs.finished_at, latest_run.max_finished_at) > 120;
+where datediff('minute', runs.finished_at, latest_run.max_finished_at) > 120
 select *
 from {{ ref('stg_simulation_runs') }}
-where finished_at < timestamp '2024-02-25 00:00:00';
+where finished_at < timestamp '2024-02-25 00:00:00'


### PR DESCRIPTION
## Summary
- remove trailing semicolons from custom freshness tests so DuckDB parsing succeeds in dbt
- drop the nonexistent `id` column assertion from the staging simulation runs model tests

## Testing
- dbt test --profiles-dir ~/.dbt --profile ce_profile *(fails: dbt not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fc4f0a35088330b64dd2c461a28bdb