### PR TITLE
Fix syntax errors in dbt freshness tests

### DIFF
--- a/tests/dbt/freshness/stg_moderation_events_freshness.sql
+++ b/tests/dbt/freshness/stg_moderation_events_freshness.sql
@@ -4,7 +4,6 @@ with latest_event as (
 select events.*
 from {{ ref('stg_moderation_events') }} events
 cross join latest_event
-where datediff('minute', events.ts, latest_event.max_ts) > 60
-select *
-from {{ ref('stg_moderation_events') }}
-where ts < timestamp '2024-02-25 00:00:00'
+where
+    datediff('minute', events.ts, latest_event.max_ts) > 60
+    or events.ts < timestamp '2024-02-25 00:00:00'

--- a/tests/dbt/freshness/stg_simulation_runs_freshness.sql
+++ b/tests/dbt/freshness/stg_simulation_runs_freshness.sql
@@ -4,7 +4,6 @@ with latest_run as (
 select runs.*
 from {{ ref('stg_simulation_runs') }} runs
 cross join latest_run
-where datediff('minute', runs.finished_at, latest_run.max_finished_at) > 120
-select *
-from {{ ref('stg_simulation_runs') }}
-where finished_at < timestamp '2024-02-25 00:00:00'
+where
+    datediff('minute', runs.finished_at, latest_run.max_finished_at) > 120
+    or runs.finished_at < timestamp '2024-02-25 00:00:00'


### PR DESCRIPTION
## Summary
- combine the predicates in the stg_moderation_events freshness test so the compiled SQL is valid
- do the same for the stg_simulation_runs freshness test

## Testing
- make dbt-ci *(fails: pip install dbt-duckdb~=1.8.0: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68fc507607048330a5e932d14069797b