### PR TITLE
Fix OpenAPI resolve apply required fields

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -69,11 +69,10 @@ paths:
                 - schema_version
                 - event_id
                 - truth
-              required:
-                - schema_version
                 - decision_id
                 - truth_source
                 - quorum
+                - quorum_details
               properties:
                 schema_version:
                   type: integer
@@ -98,7 +97,7 @@ paths:
                     ts:
                       type: string
                       format: date-time
-                quorum:
+                quorum_details:
                   type: object
                   required:
                     - value


### PR DESCRIPTION
## Summary
- consolidate the /resolve/apply request payload required fields into a single list
- rename the quorum object to quorum_details to avoid duplicate schema keys

## Testing
- npx @stoplight/spectral-cli lint api/openapi.yaml *(fails: npm returned 403 Forbidden while fetching @stoplight/spectral-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68fc5e418ce08330b43bb52a00ca05ba