### PR TITLE
Add duckdb target to dbt profile for DuckDB runs

### DIFF
--- a/ops/dbt/profiles_duckdb.yml
+++ b/ops/dbt/profiles_duckdb.yml
@@ -1,7 +1,7 @@
 ce_profile:
-  target: ci
+  target: duckdb
   outputs:
-    ci:
+    duckdb: &duckdb_output
       type: duckdb
       path: ./out/dbt/ce.duckdb
       threads: 4
@@ -10,3 +10,5 @@ ce_profile:
       settings:
         memory_limit: "1GB"
         temp_directory: "./out/dbt/tmp"
+    ci:
+      <<: *duckdb_output


### PR DESCRIPTION
## Summary
- set the DuckDB profile target to `duckdb` and expose a `ci` alias so both targets share the same configuration
- generated `out/s5-status-bundle.zip` with the current sandbox outputs (`target/INSTALL_FAILED.txt`, `out/dbt/install_attempt.log`) and recorded `out/s5-status-bundle.zip.sha256`

## Testing
- ⚠️ `pip install 'dbt-duckdb~=1.8.0'` *(fails in the sandbox: proxy blocks access to PyPI, so dbt could not be installed to execute `dbt deps/debug/run/test`)*

------
https://chatgpt.com/codex/tasks/task_e_68fc5e553ce083309705f1b2e763c31b