### PR TITLE
Remove binary bundle artifacts from repo

### DIFF
--- a/out/logs/dbt_duckdb_install_failure.log
+++ b/out/logs/dbt_duckdb_install_failure.log
@@ -1,0 +1,5 @@
+Attempted to install duckdb/dbt-duckdb via pip but encountered proxy 403 errors preventing download.
+Command: pip install duckdb dbt-duckdb
+Command: pip install dbt-duckdb==1.8.1
+See console output for details.
+Binary bundle artifacts were removed from version control to keep the repository PR-safe.


### PR DESCRIPTION
## Summary
- remove the previously committed s5-status bundle zip and checksum to avoid binary artefacts in git history
- document in the failure log that bundle artefacts were intentionally dropped for PR compliance

## Testing
- not run (non-code change)


------
https://chatgpt.com/codex/tasks/task_e_68fc5e54c33483309d8670aa1553852b