### PR TITLE
Fix dbt pipeline by ignoring DuckDB artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /out/
 !/out/
 !/out/dbt/
-!/out/dbt/ce.duckdb
+!/out/dbt/.gitkeep
 !/out/logs/
 !/out/logs/dbt_offline_runner.log
 !/out/s5-status-bundle.sha256.txt

--- a/out/dbt/ce.duckdb
+++ b/out/dbt/ce.duckdb
@@ -1,1 +1,0 @@
-offline duckdb placeholder


### PR DESCRIPTION
## Summary
- stop tracking the placeholder DuckDB database so dbt can create a valid file during CI runs
- add a .gitkeep file to keep the out/dbt directory versioned without committing generated artifacts

## Testing
- `make dbt-ci` *(fails: package install requires network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd06d1fcac8330ba4476c323de2dd5