### PR TITLE
Rename S5 workflow step labels for clarity

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -407,7 +407,7 @@ jobs:
             echo "[sut] docker/compose ausentes; nada a fazer"
           fi
 
-      - name: S5 Simulation | Deterministic Harness
+      - name: "S5 Simulation — run deterministic scenarios"
         if: ${{ inputs.run_sim }}
         shell: bash
         run: |
@@ -417,7 +417,7 @@ jobs:
           SEED=42 python -m tools.sim_harness --fixtures fixtures --scenario gap --out out/sim/gap.report.json
           SEED=42 python -m tools.sim_harness --fixtures fixtures --scenario burst --out out/sim/burst.report.json
 
-      - name: S5 DBT (DuckDB)
+      - name: "S5 DBT (DuckDB) — deps/debug/run/test"
         if: ${{ inputs.run_dbt_ci || hashFiles('dbt_project.yml') != '' }}
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- rename the Sprint 5 simulation and dbt steps in the _s4-orr workflow to the updated labels

## Testing
- ruby -ryaml -e "YAML.load_file(ARGV[0])" /tmp/sanitized.yml

------
https://chatgpt.com/codex/tasks/task_e_68fd16c66df08330856adaf019378f72