### PR TITLE
Fix boolean inputs in S4 ORR exec workflow

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -47,8 +47,8 @@ jobs:
       ref: ${{ inputs.ref }}
       run_microbench: ${{ inputs.run_microbench }}
       run_tla: ${{ inputs.run_tla }}
-      run_sut: ${{ fromJSON(github.event.inputs.run_sut || 'false') }}
+      run_sut: ${{ inputs.run_sut }}
       bq_enable: ${{ inputs.bq_enable }}
-      run_sim: ${{ fromJSON(github.event.inputs.run_sim || 'false') }}
-      run_dbt_ci: ${{ fromJSON(github.event.inputs.run_dbt_ci || 'false') }}
+      run_sim: ${{ inputs.run_sim }}
+      run_dbt_ci: ${{ inputs.run_dbt_ci }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- pass boolean inputs directly when dispatching the reusable S4 ORR workflow to avoid YAML parsing errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd2abb273083308b1c3fc185250966