### PR TITLE
Fix dbt profile setup indentation in ORR workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -426,16 +426,7 @@ jobs:
           mkdir -p out/dbt
           mkdir -p "$HOME/.dbt"
           if [ ! -f "$HOME/.dbt/profiles.yml" ]; then
-            cat <<'YAML' > "$HOME/.dbt/profiles.yml"
-ce_profile:
-  target: duckdb
-  outputs:
-    duckdb:
-      type: duckdb
-      path: out/dbt/ce.duckdb
-      schema: main
-      threads: 4
-YAML
+            python3 -c "from pathlib import Path; profile_path = Path.home() / '.dbt' / 'profiles.yml'; profile_path.write_text('ce_profile:\n  target: duckdb\n  outputs:\n    duckdb:\n      type: duckdb\n      path: out/dbt/ce.duckdb\n      schema: main\n      threads: 4\n')"
           fi
           dbt deps --profiles-dir "$HOME/.dbt" --profile ce_profile
           dbt debug --profiles-dir "$HOME/.dbt" --profile ce_profile


### PR DESCRIPTION
## Summary
- replace the dbt profile heredoc with a python -c command so the reusable workflow YAML keeps proper indentation

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68fd34379f2883309e7390d8b2421672