### PR TITLE
Update Quorum Failover Staleness dashboard metrics

### DIFF
--- a/dashboards/grafana/scorecards_quorum_failover_staleness.json
+++ b/dashboards/grafana/scorecards_quorum_failover_staleness.json
@@ -13,64 +13,67 @@
     "from": "now-24h",
     "to": "now"
   },
+  "templating": {
+    "list": []
+  },
   "panels": [
     {
       "id": 1,
-      "title": "Guard Status",
+      "title": "Quorum Ratio",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
       "targets": [
         {
           "refId": "A",
-          "expr": "avg(scorecard_guard_status)"
+          "expr": "quorum_ratio"
         }
       ]
     },
     {
       "id": 2,
-      "title": "Latency p50",
+      "title": "Failover Time p95 (s)",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.5, sum(rate(scorecard_latency_bucket[5m])) by (le))"
+          "expr": "failover_time_p95_s"
         }
       ]
     },
     {
       "id": 3,
-      "title": "Latency p95",
+      "title": "Staleness p95 (s)",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 0},
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.95, sum(rate(scorecard_latency_bucket[5m])) by (le))"
+          "expr": "staleness_p95_s"
         }
       ]
     },
     {
       "id": 4,
-      "title": "Scorecard Freshness (m)",
+      "title": "CDC Lag p95 (s)",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
       "targets": [
         {
           "refId": "A",
-          "expr": "(time() - max(scorecard_last_run_timestamp)) / 60"
+          "expr": "cdc_lag_p95_s"
         }
       ]
     },
     {
       "id": 5,
-      "title": "Boss Aggregate Ratio",
+      "title": "Divergence (%)",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 4},
+      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
       "targets": [
         {
           "refId": "A",
-          "expr": "avg(q1_boss_final_ratio)"
+          "expr": "divergence_pct"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- replace legacy stat panels with quorum ratio, failover, staleness, CDC lag, and divergence metrics
- set the dashboard templating to empty and keep the 24h time range

## Testing
- python - <<'PY'
import json
from pathlib import Path
path = Path('dashboards/grafana/scorecards_quorum_failover_staleness.json')
data = json.loads(path.read_text())
expected_exprs = {
    "Quorum Ratio": "quorum_ratio",
    "Failover Time p95 (s)": "failover_time_p95_s",
    "Staleness p95 (s)": "staleness_p95_s",
    "CDC Lag p95 (s)": "cdc_lag_p95_s",
    "Divergence (%)": "divergence_pct",
}
assert data["time"] == {"from": "now-24h", "to": "now"}
assert data.get("templating", {}).get("list", []) == []
assert len(data["panels"]) == 5
for panel in data["panels"]:
    title = panel["title"]
    assert panel["type"] == "stat", title
    assert panel.get("targets"), title
    assert panel["targets"][0]["expr"] == expected_exprs[title], title
print('dashboard schema ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68fd68edb95c8330a5801ae8f8b40679