### PR TITLE
Adopt new S6 scorecard schemas and report flow

### DIFF
--- a/s6_validation/metrics_static.json
+++ b/s6_validation/metrics_static.json
@@ -1,27 +1,36 @@
 {
-  "schema_version": 1,
-  "collected_at": "2024-09-01T05:55:00Z",
-  "metrics": [
-    {
-      "id": "trade_success_rate",
-      "value": "99.72",
-      "unit": "percent",
-      "sample_size": 18452,
-      "measurement": "rolling_24h"
-    },
-    {
-      "id": "median_settlement_latency",
-      "value": "2.103",
-      "unit": "seconds",
-      "sample_size": 18452,
-      "measurement": "rolling_24h"
-    },
-    {
-      "id": "error_budget_consumption",
-      "value": "0.1935",
+  "version": 1,
+  "timestamp_utc": "2024-09-01T05:55:00Z",
+  "metrics": {
+    "quorum_ratio": {
+      "observed": 0.92,
       "unit": "ratio",
+      "sample_size": 18630,
+      "window": "rolling_24h"
+    },
+    "failover_time_p95_s": {
+      "observed": 7.8,
+      "unit": "seconds",
+      "sample_size": 512,
+      "window": "rolling_30d"
+    },
+    "staleness_p95_s": {
+      "observed": 12.0,
+      "unit": "seconds",
+      "sample_size": 18630,
+      "window": "rolling_24h"
+    },
+    "cdc_lag_p95_s": {
+      "observed": 45.0,
+      "unit": "seconds",
+      "sample_size": 2880,
+      "window": "rolling_24h"
+    },
+    "divergence_pct": {
+      "observed": 0.4,
+      "unit": "percent",
       "sample_size": 90,
-      "measurement": "quarter_to_date"
+      "window": "quarter_to_date"
     }
-  ]
+  }
 }

--- a/s6_validation/thresholds.json
+++ b/s6_validation/thresholds.json
@@ -1,36 +1,46 @@
 {
-  "schema_version": 1,
-  "generated_at": "2024-09-01T06:00:00Z",
-  "metrics": [
-    {
-      "id": "trade_success_rate",
-      "order": 1,
-      "display_name": "Trade Success Rate",
+  "version": 1,
+  "timestamp_utc": "2024-09-01T06:00:00Z",
+  "metrics": {
+    "quorum_ratio": {
+      "display_name": "Quorum Ratio",
       "comparison": "gte",
-      "target_value": "99.5",
-      "unit": "percent",
-      "description": "Percentual de trades liquidados sem erro nas últimas 24h.",
-      "on_fail": "Acionar o runbook de estabilização de matching e revisar alarmes de retries."
-    },
-    {
-      "id": "median_settlement_latency",
-      "order": 2,
-      "display_name": "Median Settlement Latency",
-      "comparison": "lte",
-      "target_value": "2.250",
-      "unit": "seconds",
-      "description": "Latência mediana de liquidação de ordens, janela rolling 24h.",
-      "on_fail": "Verificar filas de mensageria e provisionar nós extras de processamento."
-    },
-    {
-      "id": "error_budget_consumption",
-      "order": 3,
-      "display_name": "Error Budget Consumption",
-      "comparison": "lte",
-      "target_value": "0.2500",
+      "target": 0.6667,
       "unit": "ratio",
-      "description": "Consumo acumulado do error budget trimestral.",
-      "on_fail": "Congelar deploys e abrir investigação conjunta com SRE e Produto."
+      "description": "Proporção de feeds ativos no quorum (mínimo 9 nós).",
+      "on_fail": "Ativar fallback TWAP, reiniciar oráculos inativos e revisar alertas de quorum."
+    },
+    "failover_time_p95_s": {
+      "display_name": "Failover p95",
+      "comparison": "lte",
+      "target": 60.0,
+      "unit": "seconds",
+      "description": "Tempo p95 para completar failover automático entre exchanges.",
+      "on_fail": "Executar runbook de failover e validar health-checks das rotas primárias."
+    },
+    "staleness_p95_s": {
+      "display_name": "Staleness p95",
+      "comparison": "lte",
+      "target": 30.0,
+      "unit": "seconds",
+      "description": "Janela p95 de staleness dos dados de mercado na malha MBP.",
+      "on_fail": "Investigar TWAP/heartbeats, checar latência de ingestão e recalibrar buffers."
+    },
+    "cdc_lag_p95_s": {
+      "display_name": "CDC Lag p95",
+      "comparison": "lte",
+      "target": 120.0,
+      "unit": "seconds",
+      "description": "Atraso p95 da replicação CDC para camadas analíticas.",
+      "on_fail": "Acionar squad de dados para reequilibrar consumidores e ampliar throughput do stream."
+    },
+    "divergence_pct": {
+      "display_name": "Divergence %",
+      "comparison": "lte",
+      "target": 1.0,
+      "unit": "percent",
+      "description": "Percentual p95 de divergência entre preços on-chain e fontes de referência.",
+      "on_fail": "Rever pesos de feeds, habilitar overlays e comunicar incident commander."
     }
-  ]
+  }
 }

--- a/schemas/metrics.schema.json
+++ b/schemas/metrics.schema.json
@@ -1,58 +1,135 @@
 {
+  "$id": "https://ce.local/schemas/metrics.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "S6 Metrics",
+  "title": "S6 Metrics Static",
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "schema_version",
-    "collected_at",
+    "version",
+    "timestamp_utc",
     "metrics"
   ],
   "properties": {
-    "schema_version": {
+    "version": {
       "type": "integer",
       "minimum": 1
     },
-    "collected_at": {
+    "timestamp_utc": {
       "type": "string",
       "format": "date-time"
     },
     "metrics": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "id",
-          "value",
-          "unit",
-          "sample_size",
-          "measurement"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "minLength": 1
-          },
-          "value": {
-            "type": ["string", "number"],
-            "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
-          },
-          "unit": {
-            "type": "string",
-            "enum": ["percent", "ratio", "seconds"]
-          },
-          "sample_size": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "measurement": {
-            "type": "string",
-            "minLength": 1
-          }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "quorum_ratio",
+        "failover_time_p95_s",
+        "staleness_p95_s",
+        "cdc_lag_p95_s",
+        "divergence_pct"
+      ],
+      "properties": {
+        "quorum_ratio": {
+          "$ref": "#/definitions/ratioMetric"
+        },
+        "failover_time_p95_s": {
+          "$ref": "#/definitions/secondsMetric"
+        },
+        "staleness_p95_s": {
+          "$ref": "#/definitions/secondsMetric"
+        },
+        "cdc_lag_p95_s": {
+          "$ref": "#/definitions/secondsMetric"
+        },
+        "divergence_pct": {
+          "$ref": "#/definitions/percentMetric"
         }
       }
+    }
+  },
+  "definitions": {
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observed",
+        "unit",
+        "sample_size",
+        "window"
+      ],
+      "properties": {
+        "observed": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "percent",
+            "ratio",
+            "seconds"
+          ]
+        },
+        "sample_size": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "window": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "ratioMetric": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/metric"
+        },
+        {
+          "properties": {
+            "observed": {
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "unit": {
+              "const": "ratio"
+            }
+          }
+        }
+      ]
+    },
+    "secondsMetric": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/metric"
+        },
+        {
+          "properties": {
+            "observed": {
+              "minimum": 0.0
+            },
+            "unit": {
+              "const": "seconds"
+            }
+          }
+        }
+      ]
+    },
+    "percentMetric": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/metric"
+        },
+        {
+          "properties": {
+            "observed": {
+              "minimum": 0.0
+            },
+            "unit": {
+              "const": "percent"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/schemas/report.schema.json
+++ b/schemas/report.schema.json
@@ -1,140 +1,160 @@
 {
+  "$id": "https://ce.local/schemas/report.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Sprint 6 Scorecards Report",
+  "title": "S6 Report",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "schema_version",
-    "generated_at",
-    "summary",
-    "thresholds_version",
-    "metrics_version",
-    "metrics_collected_at",
-    "items",
-    "bundle_sha256"
+    "timestamp_utc",
+    "status",
+    "metrics",
+    "inputs",
+    "bundle"
   ],
   "properties": {
     "schema_version": {
       "type": "integer",
-      "minimum": 1
+      "const": 1
     },
-    "generated_at": {
+    "timestamp_utc": {
       "type": "string",
       "format": "date-time"
     },
-    "summary": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "PASS",
+        "FAIL"
+      ]
+    },
+    "metrics": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "status",
-        "total_metrics",
-        "passing",
-        "failing"
+        "quorum_ratio",
+        "failover_time_p95_s",
+        "staleness_p95_s",
+        "cdc_lag_p95_s",
+        "divergence_pct"
       ],
       "properties": {
-        "status": {
+        "quorum_ratio": {
+          "$ref": "#/definitions/metricResult"
+        },
+        "failover_time_p95_s": {
+          "$ref": "#/definitions/metricResult"
+        },
+        "staleness_p95_s": {
+          "$ref": "#/definitions/metricResult"
+        },
+        "cdc_lag_p95_s": {
+          "$ref": "#/definitions/metricResult"
+        },
+        "divergence_pct": {
+          "$ref": "#/definitions/metricResult"
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "thresholds",
+        "metrics"
+      ],
+      "properties": {
+        "thresholds": {
+          "$ref": "#/definitions/inputMeta"
+        },
+        "metrics": {
+          "$ref": "#/definitions/inputMeta"
+        }
+      }
+    },
+    "bundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sha256"
+      ],
+      "properties": {
+        "sha256": {
           "type": "string",
-          "enum": ["pass", "fail"]
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metricResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observed",
+        "target",
+        "ok",
+        "comparison",
+        "unit",
+        "sample_size",
+        "window",
+        "delta"
+      ],
+      "properties": {
+        "observed": {
+          "type": "number"
         },
-        "total_metrics": {
+        "target": {
+          "type": "number"
+        },
+        "ok": {
+          "type": "boolean"
+        },
+        "comparison": {
+          "type": "string",
+          "enum": [
+            "gte",
+            "lte"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "percent",
+            "ratio",
+            "seconds"
+          ]
+        },
+        "sample_size": {
           "type": "integer",
           "minimum": 0
         },
-        "passing": {
-          "type": "integer",
-          "minimum": 0
+        "window": {
+          "type": "string",
+          "minLength": 1
         },
-        "failing": {
-          "type": "integer",
-          "minimum": 0
+        "delta": {
+          "type": "number"
         }
       }
     },
-    "thresholds_version": {
-      "type": ["integer", "string"]
-    },
-    "metrics_version": {
-      "type": ["integer", "string"]
-    },
-    "metrics_collected_at": {
-      "type": ["string", "null"],
-      "format": "date-time"
-    },
-    "items": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "id",
-          "display_name",
-          "status",
-          "comparison",
-          "value",
-          "formatted_value",
-          "threshold_value",
-          "formatted_threshold",
-          "unit",
-          "delta",
-          "sample_size",
-          "measurement_window",
-          "description",
-          "on_fail"
-        ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": ["pass", "fail"]
-          },
-          "comparison": {
-            "type": "string",
-            "enum": ["gte", "lte"]
-          },
-          "value": {
-            "type": "string"
-          },
-          "formatted_value": {
-            "type": "string"
-          },
-          "threshold_value": {
-            "type": "string"
-          },
-          "formatted_threshold": {
-            "type": "string"
-          },
-          "unit": {
-            "type": "string",
-            "enum": ["percent", "ratio", "seconds"]
-          },
-          "delta": {
-            "type": "string"
-          },
-          "sample_size": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "measurement_window": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "on_fail": {
-            "type": "string"
-          }
+    "inputMeta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "timestamp_utc"
+      ],
+      "properties": {
+        "version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timestamp_utc": {
+          "type": "string",
+          "format": "date-time"
         }
       }
-    },
-    "bundle_sha256": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{64}$"
     }
   }
 }

--- a/schemas/thresholds.schema.json
+++ b/schemas/thresholds.schema.json
@@ -1,73 +1,148 @@
 {
+  "$id": "https://ce.local/schemas/thresholds.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "S6 Thresholds",
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "schema_version",
-    "generated_at",
+    "version",
+    "timestamp_utc",
     "metrics"
   ],
   "properties": {
-    "schema_version": {
+    "version": {
       "type": "integer",
       "minimum": 1
     },
-    "generated_at": {
+    "timestamp_utc": {
       "type": "string",
       "format": "date-time"
     },
     "metrics": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "id",
-          "order",
-          "display_name",
-          "comparison",
-          "target_value",
-          "unit",
-          "description",
-          "on_fail"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "minLength": 1
-          },
-          "order": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "display_name": {
-            "type": "string",
-            "minLength": 1
-          },
-          "comparison": {
-            "type": "string",
-            "enum": ["gte", "lte"]
-          },
-          "target_value": {
-            "type": ["string", "number"],
-            "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
-          },
-          "unit": {
-            "type": "string",
-            "enum": ["percent", "ratio", "seconds"]
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1
-          },
-          "on_fail": {
-            "type": "string",
-            "minLength": 1
-          }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "quorum_ratio",
+        "failover_time_p95_s",
+        "staleness_p95_s",
+        "cdc_lag_p95_s",
+        "divergence_pct"
+      ],
+      "properties": {
+        "quorum_ratio": {
+          "$ref": "#/definitions/ratioThreshold"
+        },
+        "failover_time_p95_s": {
+          "$ref": "#/definitions/secondsThreshold"
+        },
+        "staleness_p95_s": {
+          "$ref": "#/definitions/secondsThreshold"
+        },
+        "cdc_lag_p95_s": {
+          "$ref": "#/definitions/secondsThreshold"
+        },
+        "divergence_pct": {
+          "$ref": "#/definitions/percentThreshold"
         }
       }
+    }
+  },
+  "definitions": {
+    "threshold": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "display_name",
+        "comparison",
+        "target",
+        "unit",
+        "description",
+        "on_fail"
+      ],
+      "properties": {
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "comparison": {
+          "type": "string",
+          "enum": [
+            "gte",
+            "lte"
+          ]
+        },
+        "target": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "percent",
+            "ratio",
+            "seconds"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "on_fail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "ratioThreshold": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/threshold"
+        },
+        {
+          "properties": {
+            "target": {
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "unit": {
+              "const": "ratio"
+            }
+          }
+        }
+      ]
+    },
+    "secondsThreshold": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/threshold"
+        },
+        {
+          "properties": {
+            "target": {
+              "minimum": 0.0
+            },
+            "unit": {
+              "const": "seconds"
+            }
+          }
+        }
+      ]
+    },
+    "percentThreshold": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/threshold"
+        },
+        {
+          "properties": {
+            "target": {
+              "minimum": 0.0
+            },
+            "unit": {
+              "const": "percent"
+            }
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace the S6 thresholds, metrics, and report schemas with the Draft-07 definitions that expose version/timestamp metadata and nested metric blocks
- realign the validation fixtures and scorecard generator with the new metric contract, uppercase statuses, and canonical bundle hash flow used by sprint guard

## Testing
- python scripts/scorecards/s6_scorecards.py
- python scripts/boss_final/sprint_guard.py --stage s6

------
https://chatgpt.com/codex/tasks/task_e_68fd68ea58ec8330884ce3ebe2aadaa0