### PR TITLE
Refactor actions.lock to map slugs to metadata objects

### DIFF
--- a/actions.lock
+++ b/actions.lock
@@ -1,21 +1,21 @@
 actions:
-  - name: actions/checkout
+  actions/checkout:
     sha: b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
-    pinned_at: 2024-09-15
+    date: 2024-09-15
     author: GitHub Actions
     rationale: Versão 4.1.0 auditada para hardening de fetch determinístico.
-  - name: actions/setup-python
+  actions/setup-python:
     sha: 57ded73d95736b4867d21e0da0f2e054fea0f6e7
-    pinned_at: 2024-09-15
+    date: 2024-09-15
     author: GitHub Actions
     rationale: Garante Python 3.11 com cache de pip e mitigação de supply-chain.
-  - name: actions/upload-artifact
+  actions/upload-artifact:
     sha: 89ef406dd8d7e03cde85f3b4a7a6b5483c8f8c7a
-    pinned_at: 2024-09-15
+    date: 2024-09-15
     author: GitHub Actions
     rationale: Publicação de artefatos com suporte a SHA256.
-  - name: actions/github-script
+  actions/github-script:
     sha: 11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
-    pinned_at: 2024-09-15
+    date: 2024-09-15
     author: GitHub Actions
     rationale: Comentário de PR com fallback para GITHUB_STEP_SUMMARY.

--- a/docs/scorecards/S6_SCORECARDS.md
+++ b/docs/scorecards/S6_SCORECARDS.md
@@ -25,11 +25,11 @@ Gerar scorecards determinísticos com contratos DbC explícitos, validação por
 
 ## Governança de Actions
 
-As ações GitHub devem ser fixadas por SHA em `.github/workflows/*.yml` e documentadas em `actions.lock`. Rotacionar SHAs a cada 30 dias ou quando surgir CVE crítico. Procedimento:
+As ações GitHub devem ser fixadas por SHA em `.github/workflows/*.yml` e documentadas em `actions.lock`. Cada slug mapeia para um objeto com as chaves `sha`, `date`, `author` e `rationale`. Rotacionar SHAs a cada 30 dias ou quando surgir CVE crítico. Procedimento:
 
 1. Abrir PR dedicado com atualização das versões.
 2. Validar hash/assinatura do commit da action.
-3. Atualizar registro correspondente em `actions.lock` com data, autor e racional.
+3. Atualizar a entrada `actions.<slug>` em `actions.lock` garantindo o objeto `{sha, date, author, rationale}`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- refactor `actions.lock` so each action slug maps to an object containing sha, date, author, and rationale
- update the Sprint 6 runbook instructions to describe the new structure and maintenance step

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd71e81bd88330916321152b897deb