### PR TITLE
Refactor actions.lock to keyed map format

### DIFF
--- a/actions.lock
+++ b/actions.lock
@@ -1,20 +1,20 @@
 actions:
-  - name: actions/checkout
+  actions/checkout:
     sha: b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
     pinned_at: 2024-09-15
     author: GitHub Actions
     rationale: Versão 4.1.0 auditada para hardening de fetch determinístico.
-  - name: actions/setup-python
+  actions/setup-python:
     sha: 57ded73d95736b4867d21e0da0f2e054fea0f6e7
     pinned_at: 2024-09-15
     author: GitHub Actions
     rationale: Garante Python 3.11 com cache de pip e mitigação de supply-chain.
-  - name: actions/upload-artifact
+  actions/upload-artifact:
     sha: 89ef406dd8d7e03cde85f3b4a7a6b5483c8f8c7a
     pinned_at: 2024-09-15
     author: GitHub Actions
     rationale: Publicação de artefatos com suporte a SHA256.
-  - name: actions/github-script
+  actions/github-script:
     sha: 11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
     pinned_at: 2024-09-15
     author: GitHub Actions

--- a/docs/scorecards/S6_SCORECARDS.md
+++ b/docs/scorecards/S6_SCORECARDS.md
@@ -31,6 +31,9 @@ As ações GitHub devem ser fixadas por SHA em `.github/workflows/*.yml` e docum
 2. Validar hash/assinatura do commit da action.
 3. Atualizar registro correspondente em `actions.lock` com data, autor e racional.
 
+O arquivo `actions.lock` deve mapear cada slug de action em `actions:` para um objeto com os campos `sha`, `pinned_at`, `author`
+e `rationale`, garantindo leitura determinística por ferramentas automatizadas.
+
 ## Troubleshooting
 
 | Sintoma | Ação |


### PR DESCRIPTION
## Summary
- refactor actions.lock to map each action slug to its metadata object
- document the keyed format requirement in the Sprint 6 scorecards runbook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd6c6ac2848330ae9dac40b50a8e66