### PR TITLE
Improve S6 scorecards CI validations

### DIFF
--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -71,16 +71,6 @@ jobs:
       - name: Validate Grafana dashboard structure (jq)
         run: |
           jq -e '
-            .title == "Scorecards Quorum Failover Staleness" and
-            .time.from == "now-24h" and
-            .time.to == "now" and
-            (.panels | length == 5) and
-            (.panels[0] | .title == "Guard Status" and .type == "stat" and .targets[0].expr == "avg(scorecard_guard_status)") and
-            (.panels[1] | .title == "Latency p50" and .type == "stat" and .targets[0].expr == "histogram_quantile(0.5, sum(rate(scorecard_latency_bucket[5m])) by (le))") and
-            (.panels[2] | .title == "Latency p95" and .type == "stat" and .targets[0].expr == "histogram_quantile(0.95, sum(rate(scorecard_latency_bucket[5m])) by (le))") and
-            (.panels[3] | .title == "Scorecard Freshness (m)" and .type == "stat" and .targets[0].expr == "(time() - max(scorecard_last_run_timestamp)) / 60") and
-            (.panels[4] | .title == "Boss Aggregate Ratio" and .type == "stat" and .targets[0].expr == "avg(q1_boss_final_ratio)")
-          ' dashboards/grafana/scorecards_quorum_failover_staleness.json > /dev/null
             def has_panel(id; title; expr):
               any(
                 .panels[];
@@ -91,25 +81,20 @@ jobs:
                 .targets[0].expr == expr
               );
 
-            if
-              (.title == "Scorecards Quorum Failover Staleness") and
-              (.time.from == "now-24h") and
-              (.time.to == "now") and
-              (.templating.list == []) and
-              (.schemaVersion == 40) and
-              (.version == 1) and
-              (.panels | length == 5) and
-              has_panel(1; "Quorum Ratio"; "avg(mbp:oracle:quorum_ratio{env=\"prod\"})") and
-              has_panel(2; "Failover p95 (s)"; "avg(mbp:oracle:failover_time_p95_s{env=\"prod\"})") and
-              has_panel(3; "Staleness p95 (s)"; "avg(mbp:oracle:staleness_p95_ms{env=\"prod\"}) / 1000") and
-              has_panel(4; "CDC Lag p95 (s)"; "max(quantile_over_time(0.95, cdc_lag_seconds{env=\"prod\"}[5m]))") and
-              has_panel(5; "Divergence (%)"; "avg(mbp:oracle:divergence_p95{env=\"prod\"}) * 100")
-            then
-              empty
-            else
-              error("Dashboard structure mismatch")
-            end
-          ' dashboards/grafana/scorecards_quorum_failover_staleness.json
+            (.title == "Scorecards Quorum Failover Staleness") and
+            (.time.from == "now-24h") and
+            (.time.to == "now") and
+            (.templating.list == []) and
+            (.schemaVersion == 40) and
+            (.version == 1) and
+            (.panels | length == 5) and
+            has_panel(1; "Quorum Ratio"; "avg(mbp:oracle:quorum_ratio{env=\"prod\"})") and
+            has_panel(2; "Failover p95 (s)"; "avg(mbp:oracle:failover_time_p95_s{env=\"prod\"})") and
+            has_panel(3; "Staleness p95 (s)"; "avg(mbp:oracle:staleness_p95_ms{env=\"prod\"}) / 1000") and
+            has_panel(4; "CDC Lag p95 (s)"; "max(quantile_over_time(0.95, cdc_lag_seconds{env=\"prod\"}[5m]))") and
+            has_panel(5; "Divergence (%)"; "avg(mbp:oracle:divergence_p95{env=\"prod\"}) * 100")
+          ' dashboards/grafana/scorecards_quorum_failover_staleness.json > /dev/null \
+            || { echo 'Dashboard structure mismatch' >&2; exit 1; }
 
       - name: Run pytest
         timeout-minutes: 5
@@ -200,10 +185,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body,
-              });
-            } catch (error) {
-              core.warning(`Falha ao publicar comentário do PR: ${error.message}`);
-                body
               });
             } catch (error) {
               core.warning(`Falha ao criar comentário no PR: ${error.message}`);


### PR DESCRIPTION
## Summary
- tighten the Grafana dashboard jq validation to ensure required panels and metadata
- ensure the PR comment step always writes the summary even when GitHub API calls fail

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd79cb21848330aadd68f57961fde7