### PR TITLE
Rebuild quorum scorecard dashboard

### DIFF
--- a/dashboards/grafana/scorecards_quorum_failover_staleness.json
+++ b/dashboards/grafana/scorecards_quorum_failover_staleness.json
@@ -16,19 +16,39 @@
   "templating": {
     "list": []
   },
+  "schemaVersion": 40,
+  "version": 1,
   "panels": [
     {
       "id": 1,
-      "title": "quorum_ratio",
-      "type": "stat",
-      "gridPos": {"h": 6, "w": 4, "x": 0, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "mbp:oracle:quorum_ratio"
       "title": "Quorum Ratio",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 5, "x": 0, "y": 0},
+      "gridPos": {"h": 6, "w": 5, "x": 0, "y": 0},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 0.66}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "targets": [
         {
           "refId": "A",
@@ -38,16 +58,34 @@
     },
     {
       "id": 2,
-      "title": "failover_time_p95_s",
+      "title": "Failover p95 (s)",
       "type": "stat",
-      "gridPos": {"h": 6, "w": 4, "x": 4, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "mbp:oracle:failover_time_p95_s"
-      "title": "Failover Time p95 (s)",
-      "type": "stat",
-      "gridPos": {"h": 4, "w": 5, "x": 5, "y": 0},
+      "gridPos": {"h": 6, "w": 5, "x": 5, "y": 0},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 60}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "targets": [
         {
           "refId": "A",
@@ -57,16 +95,34 @@
     },
     {
       "id": 3,
-      "title": "staleness_p95_s",
-      "type": "stat",
-      "gridPos": {"h": 6, "w": 4, "x": 8, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "mbp:oracle:staleness_p95_ms / 1000"
       "title": "Staleness p95 (s)",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 5, "x": 10, "y": 0},
+      "gridPos": {"h": 6, "w": 5, "x": 10, "y": 0},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 30}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "targets": [
         {
           "refId": "A",
@@ -76,16 +132,34 @@
     },
     {
       "id": 4,
-      "title": "cdc_lag_p95_s",
-      "type": "stat",
-      "gridPos": {"h": 6, "w": 4, "x": 12, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "quantile_over_time(0.95, cdc_lag_seconds{service=\"trendmarket-amm\", env=\"prod\"}[5m])"
       "title": "CDC Lag p95 (s)",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 5, "x": 15, "y": 0},
+      "gridPos": {"h": 6, "w": 5, "x": 15, "y": 0},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 120}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "targets": [
         {
           "refId": "A",
@@ -95,16 +169,34 @@
     },
     {
       "id": 5,
-      "title": "divergence_pct",
-      "type": "stat",
-      "gridPos": {"h": 6, "w": 4, "x": 16, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "mbp:oracle:divergence_p95"
       "title": "Divergence (%)",
       "type": "stat",
-      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 0},
+      "gridPos": {"h": 6, "w": 5, "x": 20, "y": 0},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "targets": [
         {
           "refId": "A",
@@ -112,10 +204,5 @@
         }
       ]
     }
-  ],
-  "templating": {
-    "list": []
-  },
-  "schemaVersion": 38,
-  "version": 1
+  ]
 }


### PR DESCRIPTION
## Summary
- replace the corrupted Grafana export with a clean five-panel stat dashboard
- wire each panel to the quorum, failover, staleness, CDC lag, and divergence Prometheus expressions with prod filtering
- ensure the dashboard metadata uses the 24h window, empty templating, and updated schema version

## Testing
- jq -e '  def has_panel(id; title; expr):    any(      .panels[];      .id == id and      .title == title and      .type == "stat" and      (.targets | length == 1) and      .targets[0].expr == expr    );    (.title == "Scorecards Quorum Failover Staleness") and    (.time.from == "now-24h") and    (.time.to == "now") and    (.templating.list == []) and    (.schemaVersion == 40) and    (.version == 1) and    (.panels | length == 5) and    has_panel(1; "Quorum Ratio"; "avg(mbp:oracle:quorum_ratio{env=\"prod\"})") and    has_panel(2; "Failover p95 (s)"; "avg(mbp:oracle:failover_time_p95_s{env=\"prod\"})") and    has_panel(3; "Staleness p95 (s)"; "avg(mbp:oracle:staleness_p95_ms{env=\"prod\"}) / 1000") and    has_panel(4; "CDC Lag p95 (s)"; "max(quantile_over_time(0.95, cdc_lag_seconds{env=\"prod\"}[5m]))") and    has_panel(5; "Divergence (%)"; "avg(mbp:oracle:divergence_p95{env=\"prod\"}) * 100")' dashboards/grafana/scorecards_quorum_failover_staleness.json > /dev/null

------
https://chatgpt.com/codex/tasks/task_e_68fd79ce7e5883309825b954056dc1cc