### PR TITLE
Align actions lock structure with slug-mapped entries

### DIFF
--- a/actions.lock
+++ b/actions.lock
@@ -4,6 +4,11 @@ actions:
     date: 2024-09-15
     author: GitHub Actions
     rationale: Versão 4.1.0 auditada para hardening de fetch determinístico.
+  actions/github-script:
+    sha: 11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
+    date: 2024-09-15
+    author: GitHub Actions
+    rationale: Comentário de PR com fallback para GITHUB_STEP_SUMMARY.
   actions/setup-python:
     sha: 57ded73d95736b4867d21e0da0f2e054fea0f6e7
     date: 2024-09-15
@@ -14,8 +19,3 @@ actions:
     date: 2024-09-15
     author: GitHub Actions
     rationale: Publicação de artefatos com suporte a SHA256.
-  actions/github-script:
-    sha: 11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
-    date: 2024-09-15
-    author: GitHub Actions
-    rationale: Comentário de PR com fallback para GITHUB_STEP_SUMMARY.

--- a/docs/scorecards/S6_SCORECARDS.md
+++ b/docs/scorecards/S6_SCORECARDS.md
@@ -35,7 +35,7 @@ As ações GitHub devem ser fixadas por SHA em `.github/workflows/*.yml` e docum
 2. Validar hash/assinatura do commit da action.
 3. Atualizar a entrada `actions.<slug>` em `actions.lock` garantindo o objeto `{sha, date, author, rationale}`.
 
-O arquivo `actions.lock` deve mapear cada slug de action em `actions:` para um objeto com os campos `sha`, `pinned_at`, `author`
+O arquivo `actions.lock` deve mapear cada slug de action em `actions:` para um objeto com os campos `sha`, `date`, `author`
 e `rationale`, garantindo leitura determinística por ferramentas automatizadas.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- reorder `actions.lock` entries so each slug maps directly to its `{sha, date, author, rationale}` metadata
- refresh the Sprint 6 scorecard runbook to document the updated `actions.lock` schema

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd79ce973c833085e2863090f76ec1