### PR TITLE
Add property-based scorecard tests and clean runner matrices

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -11,7 +11,9 @@ on:
         type: string
   pull_request:
 
-concurrency: q1-boss-final-${{ github.ref }}
+concurrency:
+  group: q1-boss-final-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   LC_ALL: C.UTF-8
@@ -23,15 +25,22 @@ env:
 
 jobs:
   stage:
-    name: Stage ${{ matrix.stage }}
+    name: Stage ${{ matrix.stage }} (clean=${{ matrix.clean_runner }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         stage: [s1, s2, s3, s4, s5, s6]
+        clean_runner: [true, false]
+    env:
+      CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+
+      - name: Log clean runner mode
+        run: echo "clean_runner=${{ matrix.clean_runner }}"
 
       - name: Set up Python
         uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7
@@ -40,8 +49,7 @@ jobs:
           cache: 'pip'
 
       - name: Upgrade packaging toolchain
-        run: |
-          python -m pip install --upgrade pip==24.2 setuptools==75.1.0 wheel==0.44.0
+        run: python -m pip install --upgrade pip==24.2 setuptools==75.1.0 wheel==0.44.0
 
       - name: Install Python dependencies
         run: |
@@ -96,11 +104,19 @@ jobs:
     needs: stage
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        clean_runner: [true, false]
     env:
       REPORT_DIR: out/q1_boss_final
+      CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+
+      - name: Log clean runner mode
+        run: echo "clean_runner=${{ matrix.clean_runner }}"
 
       - name: Set up Python
         uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7
@@ -109,8 +125,7 @@ jobs:
           cache: 'pip'
 
       - name: Upgrade packaging toolchain
-        run: |
-          python -m pip install --upgrade pip==24.2 setuptools==75.1.0 wheel==0.44.0
+        run: python -m pip install --upgrade pip==24.2 setuptools==75.1.0 wheel==0.44.0
 
       - name: Install Python dependencies
         run: |
@@ -147,24 +162,42 @@ jobs:
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
+        env:
+          REPORT_DIR: ${{ env.REPORT_DIR }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
+
             const reportDir = process.env.REPORT_DIR;
-            const commentPath = path.join(reportDir, 'pr_comment.md');
-            let body;
-            if (fs.existsSync(commentPath)) {
-              body = fs.readFileSync(commentPath, 'utf8');
-            } else {
-              body = '⚠️ Relatório não encontrado. Veja GITHUB_STEP_SUMMARY para detalhes.';
+            const commentPath = reportDir ? path.join(reportDir, 'pr_comment.md') : undefined;
+            let body = '⚠️ Relatório não encontrado. Veja GITHUB_STEP_SUMMARY para detalhes.';
+
+            if (!reportDir) {
+              core.warning('Variável de ambiente REPORT_DIR não definida; usando mensagem padrão.');
+            } else if (commentPath && fs.existsSync(commentPath)) {
+              try {
+                body = fs.readFileSync(commentPath, 'utf8');
+              } catch (fileError) {
+                core.warning(`Falha ao ler comentário gerado: ${fileError.message}`);
+              }
             }
-            core.summary.addHeading('Q1 Boss Final');
-            core.summary.addRaw(body);
-            core.summary.write();
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            });
+
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            } catch (error) {
+              core.warning(`Falha ao criar comentário no PR: ${error.message}`);
+            } finally {
+              try {
+                core.summary.addHeading('Q1 Boss Final');
+                core.summary.addRaw(body);
+                await core.summary.write();
+              } catch (summaryError) {
+                core.warning(`Falha ao escrever GITHUB_STEP_SUMMARY: ${summaryError.message}`);
+              }
+            }

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -15,12 +15,18 @@ on:
       - 'docs/scorecards/**'
       - 'Makefile'
 
-concurrency: { group: s6-scorecards-${{ github.ref }}, cancel-in-progress: true }
+concurrency:
+  group: s6-scorecards-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   scorecards:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        clean_runner: [true, false]
     env:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
@@ -29,9 +35,13 @@ jobs:
       HYPOTHESIS_PROFILE: ci
       HYPOTHESIS_SEED: '12345'
       REPORT_DIR: out/s6_scorecards
+      CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+
+      - name: Log clean runner mode
+        run: echo "clean_runner=${{ matrix.clean_runner }}"
 
       - name: Set up Python
         uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7
@@ -40,8 +50,7 @@ jobs:
           cache: 'pip'
 
       - name: Upgrade packaging toolchain
-        run: |
-          python -m pip install --upgrade pip==24.2 setuptools==75.1.0 wheel==0.44.0
+        run: python -m pip install --upgrade pip==24.2 setuptools==75.1.0 wheel==0.44.0
 
       - name: Install Python dependencies
         run: |
@@ -71,16 +80,6 @@ jobs:
       - name: Validate Grafana dashboard structure (jq)
         run: |
           jq -e '
-            .title == "Scorecards Quorum Failover Staleness" and
-            .time.from == "now-24h" and
-            .time.to == "now" and
-            (.panels | length == 5) and
-            (.panels[0] | .title == "Guard Status" and .type == "stat" and .targets[0].expr == "avg(scorecard_guard_status)") and
-            (.panels[1] | .title == "Latency p50" and .type == "stat" and .targets[0].expr == "histogram_quantile(0.5, sum(rate(scorecard_latency_bucket[5m])) by (le))") and
-            (.panels[2] | .title == "Latency p95" and .type == "stat" and .targets[0].expr == "histogram_quantile(0.95, sum(rate(scorecard_latency_bucket[5m])) by (le))") and
-            (.panels[3] | .title == "Scorecard Freshness (m)" and .type == "stat" and .targets[0].expr == "(time() - max(scorecard_last_run_timestamp)) / 60") and
-            (.panels[4] | .title == "Boss Aggregate Ratio" and .type == "stat" and .targets[0].expr == "avg(q1_boss_final_ratio)")
-          ' dashboards/grafana/scorecards_quorum_failover_staleness.json > /dev/null
             def has_panel(id; title; expr):
               any(
                 .panels[];
@@ -91,25 +90,19 @@ jobs:
                 .targets[0].expr == expr
               );
 
-            if
-              (.title == "Scorecards Quorum Failover Staleness") and
-              (.time.from == "now-24h") and
-              (.time.to == "now") and
-              (.templating.list == []) and
-              (.schemaVersion == 40) and
-              (.version == 1) and
-              (.panels | length == 5) and
-              has_panel(1; "Quorum Ratio"; "avg(mbp:oracle:quorum_ratio{env=\"prod\"})") and
-              has_panel(2; "Failover p95 (s)"; "avg(mbp:oracle:failover_time_p95_s{env=\"prod\"})") and
-              has_panel(3; "Staleness p95 (s)"; "avg(mbp:oracle:staleness_p95_ms{env=\"prod\"}) / 1000") and
-              has_panel(4; "CDC Lag p95 (s)"; "max(quantile_over_time(0.95, cdc_lag_seconds{env=\"prod\"}[5m]))") and
-              has_panel(5; "Divergence (%)"; "avg(mbp:oracle:divergence_p95{env=\"prod\"}) * 100")
-            then
-              empty
-            else
-              error("Dashboard structure mismatch")
-            end
-          ' dashboards/grafana/scorecards_quorum_failover_staleness.json
+            (.title == "Scorecards Quorum Failover Staleness") and
+            (.time.from == "now-24h") and
+            (.time.to == "now") and
+            (.templating.list == []) and
+            (.schemaVersion == 40) and
+            (.version == 1) and
+            (.panels | length == 5) and
+            has_panel(1; "Quorum Ratio"; "avg(mbp:oracle:quorum_ratio{env=\"prod\"})") and
+            has_panel(2; "Failover p95 (s)"; "avg(mbp:oracle:failover_time_p95_s{env=\"prod\"})") and
+            has_panel(3; "Staleness p95 (s)"; "avg(mbp:oracle:staleness_p95_ms{env=\"prod\"}) / 1000") and
+            has_panel(4; "CDC Lag p95 (s)"; "max(quantile_over_time(0.95, cdc_lag_seconds{env=\"prod\"}[5m]))") and
+            has_panel(5; "Divergence (%)"; "avg(mbp:oracle:divergence_p95{env=\"prod\"}) * 100")
+          ' dashboards/grafana/scorecards_quorum_failover_staleness.json > /dev/null
 
       - name: Run pytest
         timeout-minutes: 5
@@ -162,17 +155,19 @@ jobs:
         run: python -m jsonschema --instance "$REPORT_DIR/report.json" --schema schemas/report.schema.json
 
       - name: Evaluate guard status
+        id: guard
         run: |
           status=$(cat "$REPORT_DIR/guard_status.txt")
           echo "guard_status=$status" >> $GITHUB_OUTPUT
           if [ "$status" != "PASS" ]; then
             exit 1
           fi
-        id: guard
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
+        env:
+          REPORT_DIR: ${{ env.REPORT_DIR }}
         with:
           script: |
             const fs = require('fs');
@@ -184,11 +179,9 @@ jobs:
 
             if (!reportDir) {
               core.warning('Variável de ambiente REPORT_DIR não definida; usando mensagem padrão.');
-            } else {
+            } else if (commentPath && fs.existsSync(commentPath)) {
               try {
-                if (fs.existsSync(commentPath)) {
-                  body = fs.readFileSync(commentPath, 'utf8');
-                }
+                body = fs.readFileSync(commentPath, 'utf8');
               } catch (fileError) {
                 core.warning(`Falha ao ler comentário gerado: ${fileError.message}`);
               }
@@ -200,10 +193,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body,
-              });
-            } catch (error) {
-              core.warning(`Falha ao publicar comentário do PR: ${error.message}`);
-                body
               });
             } catch (error) {
               core.warning(`Falha ao criar comentário no PR: ${error.message}`);

--- a/scripts/scorecards/s6_scorecards.py
+++ b/scripts/scorecards/s6_scorecards.py
@@ -1,35 +1,52 @@
 #!/usr/bin/env python3
+"""Generate Sprint 6 scorecard artifacts.
+
+The script evaluates the metrics stored in ``s6_validation/metrics_static.json``
+against the thresholds defined in ``s6_validation/thresholds.json``.  Besides
+returning the evaluation in memory it also materialises a bundle of artifacts
+in ``out/s6_scorecards`` so that the CI pipeline and the Boss Final aggregator
+can consume them.
+
+The original version of this file accidentally contained duplicated function
+definitions and unfinished refactors which made importing it impossible.  The
+tests added in this change exercise the whole flow and would have immediately
+flagged the broken module.
+"""
+
 from __future__ import annotations
 
 import hashlib
 import json
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal, ROUND_HALF_EVEN, getcontext
+from decimal import ROUND_HALF_EVEN, Decimal, getcontext
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, Iterable, List
+
+import jsonschema
 
 BASE_DIR = Path(__file__).resolve().parents[2]
-sys.path.append(str(BASE_DIR))
-
-import jsonschema  # noqa: E402
-
-getcontext().prec = 28
-getcontext().rounding = ROUND_HALF_EVEN
-
-EPSILON = Decimal("1e-12")
 THRESHOLD_PATH = BASE_DIR / "s6_validation" / "thresholds.json"
 METRICS_PATH = BASE_DIR / "s6_validation" / "metrics_static.json"
 SCHEMAS_DIR = BASE_DIR / "schemas"
 OUTPUT_DIR = BASE_DIR / "out" / "s6_scorecards"
+
+EPSILON = Decimal("1e-12")
 ERROR_PREFIX = "S6"
+
+getcontext().prec = 28
+getcontext().rounding = ROUND_HALF_EVEN
+
+
+class ScorecardError(RuntimeError):
+    """Exception raised for recoverable scorecard failures."""
+
+    def __init__(self, code: str, message: str):
+        self.code = f"{ERROR_PREFIX}-E-{code}"
+        super().__init__(f"{self.code}:{message}")
 
 
 @dataclass(frozen=True)
-class MetricConfig:
-    key: str
-    threshold_key: str
 class MetricSpec:
     key: str
     label: str
@@ -118,77 +135,6 @@ METRIC_SPECS: List[MetricSpec] = [
         markdown_suffix="%",
     ),
 ]
-class Threshold:
-    metric_id: str
-    display_name: str
-    comparison: str
-    display_name: str
-    unit: str
-    on_fail: str
-
-
-@dataclass(frozen=True)
-class Evaluation:
-    config: MetricConfig
-    observed: Decimal
-    target: Decimal
-    ok: bool
-
-
-METRICS: List[MetricConfig] = [
-    MetricConfig(
-        key="quorum_ratio",
-        threshold_key="quorum_ratio_min",
-        comparison="gte",
-        display_name="Quorum Ratio",
-        unit="ratio",
-        on_fail="Ativar fallback TWAP, reiniciar oráculos inativos e revisar alertas de quorum.",
-    ),
-    MetricConfig(
-        key="failover_time_p95_s",
-        threshold_key="failover_time_p95_s_max",
-        comparison="lte",
-        display_name="Failover p95",
-        unit="seconds",
-        on_fail="Executar runbook de failover e validar health-checks das rotas primárias.",
-    ),
-    MetricConfig(
-        key="staleness_p95_s",
-        threshold_key="staleness_p95_s_max",
-        comparison="lte",
-        display_name="Staleness p95",
-        unit="seconds",
-        on_fail="Investigar TWAP/heartbeats, checar latência de ingestão e recalibrar buffers.",
-    ),
-    MetricConfig(
-        key="cdc_lag_p95_s",
-        threshold_key="cdc_lag_p95_s_max",
-        comparison="lte",
-        display_name="CDC Lag p95",
-        unit="seconds",
-        on_fail="Acionar squad de dados para reequilibrar consumidores e ampliar throughput do stream.",
-    ),
-    MetricConfig(
-        key="divergence_pct",
-        threshold_key="divergence_pct_max",
-        comparison="lte",
-        display_name="Divergence %",
-        unit="percent",
-        on_fail="Rever pesos de feeds, habilitar overlays e comunicar incident commander.",
-    ),
-]
-
-FORMATTERS = {
-    "percent": lambda value: f"{value.quantize(Decimal('0.1'))}%",
-    "ratio": lambda value: f"{value.quantize(Decimal('0.0001'))}",
-    "seconds": lambda value: f"{value.quantize(Decimal('0.001'))}s",
-}
-
-SCHEMA_FILES = {
-    "thresholds": SCHEMAS_DIR / "thresholds.schema.json",
-    "metrics": SCHEMAS_DIR / "metrics.schema.json",
-    "report": SCHEMAS_DIR / "report.schema.json",
-}
 
 
 def _format_decimal(value: Decimal, suffix: str) -> str:
@@ -197,7 +143,18 @@ def _format_decimal(value: Decimal, suffix: str) -> str:
 
 
 def fail(code: str, message: str) -> None:
-    raise RuntimeError(f"{ERROR_PREFIX}-E-{code}:{message}")
+    raise ScorecardError(code, message)
+
+
+def _schema_path(key: str) -> Path:
+    mapping = {
+        "thresholds": SCHEMAS_DIR / "thresholds.schema.json",
+        "metrics": SCHEMAS_DIR / "metrics.schema.json",
+    }
+    try:
+        return mapping[key]
+    except KeyError as exc:  # pragma: no cover - guard for new keys
+        raise KeyError(f"Unknown schema key: {key}") from exc
 
 
 def load_json(path: Path, schema_key: str) -> Dict[str, object]:
@@ -209,16 +166,18 @@ def load_json(path: Path, schema_key: str) -> Dict[str, object]:
         fail("ENCODING", f"Arquivo não está em UTF-8: {path}: {exc}")
     except OSError as exc:
         fail("IO", f"Falha ao ler {path}: {exc}")
+
     try:
         content = json.loads(raw_text)
     except json.JSONDecodeError as exc:
         fail("INVALID-JSON", f"Falha ao decodificar {path}: {exc}")
-    schema_path = SCHEMA_FILES[schema_key]
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    schema = json.loads(_schema_path(schema_key).read_text(encoding="utf-8"))
     try:
         jsonschema.validate(instance=content, schema=schema)
     except jsonschema.ValidationError as exc:
         fail("SCHEMA", f"Violação de schema em {path}: {exc.message}")
+
     return content
 
 
@@ -228,25 +187,46 @@ def decimal_from(value: object) -> Decimal:
     if isinstance(value, (int, float, str)):
         try:
             return Decimal(str(value))
-        except Exception as exc:  # pragma: no cover
+        except Exception as exc:  # pragma: no cover - str conversion
             fail("DECIMAL", f"Valor inválido para Decimal: {value} ({exc})")
     fail("DECIMAL", f"Valor não numérico: {value}")
 
 
-def evaluate_metrics(thresholds: Dict[str, object], metrics: Dict[str, object]) -> List[MetricResult]:
+def _compare(observed: Decimal, target: Decimal, comparison: str) -> bool:
+    if comparison == "gte":
+        return observed + EPSILON >= target
+    if comparison == "lte":
+        return observed - EPSILON <= target
+    fail("COMPARISON", f"Operador desconhecido: {comparison}")
+    return False  # pragma: no cover - unreachable due to fail()
+
+
+def evaluate_metrics(
+    thresholds: Dict[str, object], metrics: Dict[str, object]
+) -> List[MetricResult]:
     results: List[MetricResult] = []
     for spec in METRIC_SPECS:
-        observed = decimal_from(metrics[spec.key])
-        target = decimal_from(thresholds[spec.threshold_key])
-        if spec.comparison == "gte":
-            ok = observed + EPSILON >= target
-        else:
-            ok = observed - EPSILON <= target
-        results.append(MetricResult(spec=spec, observed=observed, target=target, ok=bool(ok)))
+        try:
+            observed_value = decimal_from(metrics[spec.key])
+        except KeyError:
+            fail("MISSING-METRIC", f"Métrica sem coleta: {spec.key}")
+        try:
+            target_value = decimal_from(thresholds[spec.threshold_key])
+        except KeyError:
+            fail("MISSING-THRESHOLD", f"Threshold ausente para {spec.threshold_key}")
+        ok = _compare(observed_value, target_value, spec.comparison)
+        results.append(
+            MetricResult(
+                spec=spec,
+                observed=observed_value,
+                target=target_value,
+                ok=ok,
+            )
+        )
     return results
 
 
-def compute_status(results: List[MetricResult]) -> str:
+def compute_status(results: Iterable[MetricResult]) -> str:
     return "PASS" if all(result.ok for result in results) else "FAIL"
 
 
@@ -256,10 +236,6 @@ def isoformat_utc() -> str:
 
 def canonical_dumps(data: Dict[str, object]) -> str:
     return json.dumps(data, sort_keys=True, ensure_ascii=False, separators=(",", ":")) + "\n"
-
-
-def ensure_output_dir() -> None:
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def render_markdown(
@@ -284,8 +260,13 @@ def render_markdown(
     for result in results:
         emoji_metric = "✅" if result.ok else "❌"
         lines.append(
-            f"| {result.spec.label} | {result.formatted_observed()} | {result.formatted_target()} | "
-            f"{emoji_metric} {result.status_text()} |"
+            "| {label} | {observed} | {target} | {emoji} {status} |".format(
+                label=result.spec.label,
+                observed=result.formatted_observed(),
+                target=result.formatted_target(),
+                emoji=emoji_metric,
+                status=result.status_text(),
+            )
         )
     lines.append("")
     lines.append("## O que fazer agora")
@@ -293,151 +274,14 @@ def render_markdown(
     if failing:
         for result in failing:
             lines.append(f"- {result.spec.label}: executar runbook de correção e revisar telemetria.")
-    try:
-        return Decimal(str(value))
-    except Exception as exc:  # pragma: no cover
-        fail("DECIMAL", f"Valor inválido para Decimal: {value} ({exc})")
-        raise
-
-
-def parse_thresholds(data: Dict) -> Dict[str, Decimal]:
-    thresholds: Dict[str, Decimal] = {}
-    for config in METRICS:
-        if config.threshold_key not in data:
-            fail("MISSING-THRESHOLD", f"Threshold ausente para {config.threshold_key}")
-        thresholds[config.key] = decimal_from(data[config.threshold_key])
-    return thresholds
-
-
-def parse_measurements(data: Dict) -> Dict[str, Decimal]:
-    measurements: Dict[str, Decimal] = {}
-    for config in METRICS:
-        if config.key not in data:
-            fail("MISSING-METRIC", f"Métrica sem coleta: {config.key}")
-        measurements[config.key] = decimal_from(data[config.key])
-    return measurements
-
-
-def compare(observed: Decimal, target: Decimal, comparison: str) -> bool:
-    if comparison == "gte":
-        return observed + EPSILON >= target
-    if comparison == "lte":
-        return observed - EPSILON <= target
-    fail("COMPARISON", f"Operador desconhecido: {comparison}")
-    return False
-
-
-def evaluate(thresholds: Dict[str, Decimal], measurements: Dict[str, Decimal]) -> List[Evaluation]:
-    evaluations: List[Evaluation] = []
-    for config in METRICS:
-        target = thresholds[config.key]
-        observed = measurements.get(config.key)
-        if observed is None:
-            fail("MISSING-METRIC", f"Métrica sem coleta: {config.key}")
-        ok = compare(observed, target, config.comparison)
-        evaluations.append(Evaluation(config=config, observed=observed, target=target, ok=ok))
-    return evaluations
-
-
-def format_value(value: Decimal, unit: str) -> str:
-    formatter = FORMATTERS.get(unit)
-    if formatter is None:  # pragma: no cover
-        return str(value)
-    return formatter(value)
-
-
-def canonical_dump(data: Dict) -> str:
-    return json.dumps(data, sort_keys=True, ensure_ascii=False, separators=(",", ":")) + "\n"
-
-
-def compute_bundle_sha(thresholds_raw: Dict, metrics_raw: Dict) -> str:
-    payload = canonical_dump(thresholds_raw) + canonical_dump(metrics_raw)
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
-
-
-def build_report(
-    evaluations: List[Evaluation],
-    generated_at: str,
-    thresholds_meta: Dict,
-    metrics_meta: Dict,
-    bundle_hash: str,
-) -> Dict[str, object]:
-    metrics_block: Dict[str, Dict[str, object]] = {}
-    for evaluation in evaluations:
-        config = evaluation.config
-        metrics_block[config.key] = {
-            "observed": float(evaluation.observed),
-            "target": float(evaluation.target),
-            "ok": evaluation.ok,
-        }
-    status = "PASS" if all(evaluation.ok for evaluation in evaluations) else "FAIL"
-    return {
-        "schema_version": 1,
-        "timestamp_utc": generated_at,
-        "status": status,
-        "metrics": metrics_block,
-        "inputs": {
-            "thresholds": {
-                "version": thresholds_meta["version"],
-                "timestamp_utc": thresholds_meta["timestamp_utc"],
-            },
-            "metrics": {
-                "version": metrics_meta["version"],
-                "timestamp_utc": metrics_meta["timestamp_utc"],
-            },
-        },
-        "bundle": {
-            "sha256": bundle_hash,
-        },
-    }
-
-
-def render_markdown(report: Dict[str, object], evaluations: List[Evaluation]) -> str:
-    lines = ["# Sprint 6 Scorecards", ""]
-    status_emoji = "✅" if report["status"] == "PASS" else "❌"
-    lines.append(f"{status_emoji} Status geral: **{report['status']}**")
-    lines.append("")
-    lines.append("| Métrica | Observado | Limite | Status |")
-    lines.append("| --- | --- | --- | --- |")
-    for evaluation in evaluations:
-        config = evaluation.config
-        status = "✅" if evaluation.ok else "❌"
-        lines.append(
-            "| {name} | {observed} | {target} | {status} |".format(
-                name=config.display_name,
-                observed=format_value(evaluation.observed, config.unit),
-                target=format_value(evaluation.target, config.unit),
-                status=status,
-            )
-        )
-    lines.append("")
-    lines.append("## O que fazer agora")
-    failing = [evaluation for evaluation in evaluations if not evaluation.ok]
-    if failing:
-        for evaluation in failing:
-            lines.append(f"- {evaluation.config.display_name}: {evaluation.config.on_fail}")
     else:
-        lines.append("- Todas as métricas passaram. Manter monitoramento em 24h.")
+        lines.append("- Nenhuma ação imediata necessária.")
     lines.append("")
+    lines.append("Relatório completo disponível em [report.json](./report.json).")
     return "\n".join(lines) + "\n"
 
 
-def build_pr_comment(report: Dict[str, object], results: List[MetricResult], bundle_sha256: str) -> str:
-    status = report["status"]
-    emoji = "✅" if status == "PASS" else "❌"
-    lines.append("## Metadados")
-    lines.append(
-        f"- Thresholds: v{report['inputs']['thresholds']['version']} @ {report['inputs']['thresholds']['timestamp_utc']}"
-    )
-    lines.append(
-        f"- Métricas: v{report['inputs']['metrics']['version']} @ {report['inputs']['metrics']['timestamp_utc']}"
-    )
-    lines.append(f"- Gerado em: {report['timestamp_utc']}")
-    lines.append(f"- SHA do bundle: `{report['bundle']['sha256']}`")
-    return "\n".join(lines) + "\n"
-
-
-def build_pr_comment(report: Dict[str, object], evaluations: List[Evaluation]) -> str:
+def build_pr_comment(report: Dict[str, object], results: List[MetricResult]) -> str:
     emoji = "✅" if report["status"] == "PASS" else "❌"
     lines = [f"{emoji} [Sprint 6 report](./report.md)"]
     lines.append("")
@@ -451,7 +295,7 @@ def build_pr_comment(report: Dict[str, object], evaluations: List[Evaluation]) -
     else:
         lines.append("- Nenhuma ação imediata necessária.")
     lines.append("")
-    lines.append(f"Bundle SHA-256: `{bundle_sha256}`")
+    lines.append(f"Bundle SHA-256: `{report['bundle']['sha256']}`")
     lines.append("")
     lines.append("Relatório completo disponível em [report.md](./report.md).")
     return "\n".join(lines) + "\n"
@@ -459,20 +303,6 @@ def build_pr_comment(report: Dict[str, object], evaluations: List[Evaluation]) -
 
 def render_svg_badge(status: str) -> str:
     color = "#2e8540" if status == "PASS" else "#c92a2a"
-    failing = [evaluation for evaluation in evaluations if not evaluation.ok]
-    if failing:
-        for evaluation in failing:
-            lines.append(f"- {evaluation.config.display_name}: {evaluation.config.on_fail}")
-    else:
-        lines.append("- Nenhuma ação imediata necessária.")
-    lines.append("")
-    lines.append("Detalhes completos em [report.md](./report.md).")
-    return "\n".join(lines) + "\n"
-
-
-def render_svg_badge(report: Dict[str, object]) -> str:
-    status = report["status"]
-    label_color = "#2e8540" if status == "PASS" else "#c92a2a"
     return (
         "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"160\" height=\"40\">"
         f"<rect width=\"160\" height=\"40\" fill=\"{color}\" rx=\"6\"/>"
@@ -484,8 +314,6 @@ def render_svg_badge(report: Dict[str, object]) -> str:
 
 def render_scorecard_svg(status: str, results: List[MetricResult]) -> str:
     rows = len(results)
-def render_scorecard_svg(evaluations: List[Evaluation]) -> str:
-    rows = len(evaluations)
     height = 60 + 30 * rows
     header = (
         f"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"520\" height=\"{height}\">"
@@ -501,17 +329,8 @@ def render_scorecard_svg(evaluations: List[Evaluation]) -> str:
         lines.append(
             f"<text x=\"20\" y=\"{y}\">{result.spec.label}</text>"
             f"<text x=\"260\" y=\"{y}\">{result.formatted_observed()}</text>"
-            f"<text x=\"370\" y=\"{y}\">{result.formatted_target()}</text>"
+            f"<text x=\"360\" y=\"{y}\">{result.formatted_target()}</text>"
             f"<text x=\"460\" y=\"{y}\" fill=\"{status_color}\">{result.status_text()}</text>"
-    for evaluation in evaluations:
-        config = evaluation.config
-        status_color = "#2e8540" if evaluation.ok else "#c92a2a"
-        status_text = "PASS" if evaluation.ok else "FAIL"
-        lines.append(
-            f"<text x=\"20\" y=\"{y}\">{config.display_name}</text>"
-            f"<text x=\"260\" y=\"{y}\">{format_value(evaluation.observed, config.unit)}</text>"
-            f"<text x=\"360\" y=\"{y}\">{format_value(evaluation.target, config.unit)}</text>"
-            f"<text x=\"460\" y=\"{y}\" fill=\"{status_color}\">{status_text}</text>"
         )
         y += 30
     lines.append("</svg>")
@@ -525,11 +344,13 @@ def write_outputs(
     thresholds_version: int,
     metrics_version: int,
 ) -> None:
-    ensure_output_dir()
-    (OUTPUT_DIR / "report.json").write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUTPUT_DIR / "report.json").write_text(
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     markdown = render_markdown(report, results, bundle_sha256, thresholds_version, metrics_version)
     (OUTPUT_DIR / "report.md").write_text(markdown, encoding="utf-8")
-    pr_comment = build_pr_comment(report, results, bundle_sha256)
+    pr_comment = build_pr_comment(report, results)
     (OUTPUT_DIR / "pr_comment.md").write_text(pr_comment, encoding="utf-8")
     badge_svg = render_svg_badge(report["status"])
     (OUTPUT_DIR / "badge.svg").write_text(badge_svg + "\n", encoding="utf-8")
@@ -540,17 +361,17 @@ def write_outputs(
 
 
 def generate_report(
-    threshold_path: Path = THRESHOLD_PATH,
-    metrics_path: Path = METRICS_PATH,
+    threshold_path: Path = THRESHOLD_PATH, metrics_path: Path = METRICS_PATH
 ) -> ScorecardArtifacts:
     thresholds_raw = load_json(threshold_path, "thresholds")
     metrics_raw = load_json(metrics_path, "metrics")
     results = evaluate_metrics(thresholds_raw, metrics_raw)
+    status = compute_status(results)
     timestamp = isoformat_utc()
     report = {
         "schema_version": 1,
         "timestamp_utc": timestamp,
-        "status": compute_status(results),
+        "status": status,
         "metrics": {
             result.spec.key: {
                 "observed": result.observed_for_json(),
@@ -559,9 +380,22 @@ def generate_report(
             }
             for result in results
         },
+        "inputs": {
+            "thresholds": {
+                "version": int(thresholds_raw["version"]),
+                "timestamp_utc": thresholds_raw["timestamp_utc"],
+            },
+            "metrics": {
+                "version": int(metrics_raw["version"]),
+                "timestamp_utc": metrics_raw["timestamp_utc"],
+            },
+        },
     }
+
     bundle_payload = canonical_dumps(thresholds_raw) + canonical_dumps(metrics_raw)
     bundle_hash = hashlib.sha256(bundle_payload.encode("utf-8")).hexdigest()
+    report["bundle"] = {"sha256": bundle_hash}
+
     write_outputs(
         report,
         results,
@@ -569,6 +403,7 @@ def generate_report(
         int(thresholds_raw["version"]),
         int(metrics_raw["version"]),
     )
+
     return ScorecardArtifacts(
         report=report,
         results=results,
@@ -583,7 +418,7 @@ def main() -> int:
         artifacts = generate_report()
     except ScorecardError as exc:
         print(f"FAIL {exc}")
-        ensure_output_dir()
+        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
         (OUTPUT_DIR / "guard_status.txt").write_text("FAIL\n", encoding="utf-8")
         return 1
     else:
@@ -591,52 +426,8 @@ def main() -> int:
         prefix = "PASS" if status == "PASS" else "FAIL"
         print(f"{prefix} Sprint 6 scorecards")
         return 0
-def write_file(path: Path, content: str) -> None:
-    path.write_text(content, encoding="utf-8")
-
-
-def write_outputs(report: Dict[str, object], evaluations: List[Evaluation]) -> None:
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    write_file(OUTPUT_DIR / "report.json", json.dumps(report, indent=2, ensure_ascii=False) + "\n")
-    markdown = render_markdown(report, evaluations)
-    write_file(OUTPUT_DIR / "report.md", markdown)
-    write_file(OUTPUT_DIR / "pr_comment.md", build_pr_comment(report, evaluations))
-    badge_svg = render_svg_badge(report)
-    write_file(OUTPUT_DIR / "badge.svg", badge_svg + "\n")
-    scorecard_svg = render_scorecard_svg(evaluations)
-    write_file(OUTPUT_DIR / "scorecard.svg", scorecard_svg + "\n")
-    write_file(OUTPUT_DIR / "guard_status.txt", report["status"] + "\n")
-    write_file(OUTPUT_DIR / "bundle.sha256", report["bundle"]["sha256"] + "\n")
-
-
-def generate_report(threshold_path: Path = THRESHOLD_PATH, metrics_path: Path = METRICS_PATH) -> Dict[str, object]:
-    try:
-        thresholds_raw = load_json(threshold_path, "thresholds")
-        metrics_raw = load_json(metrics_path, "metrics")
-        thresholds = parse_thresholds(thresholds_raw)
-        measurements = parse_measurements(metrics_raw)
-        evaluations = evaluate(thresholds, measurements)
-        generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-        bundle_hash = compute_bundle_sha(thresholds_raw, metrics_raw)
-        report = build_report(evaluations, generated_at, thresholds_raw, metrics_raw, bundle_hash)
-        write_outputs(report, evaluations)
-    except RuntimeError as exc:
-        print(f"FAIL {exc}")
-        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-        write_file(OUTPUT_DIR / "guard_status.txt", "FAIL\n")
-        raise
-    else:
-        print("PASS Sprint 6 scorecards")
-        return report
-
-
-def main() -> int:
-    try:
-        generate_report()
-    except RuntimeError:
-        return 1
-    return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/tests/scorecards/test_s6_scorecards.py
+++ b/tests/scorecards/test_s6_scorecards.py
@@ -6,183 +6,54 @@ from decimal import Decimal
 from pathlib import Path
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import HealthCheck, given, seed, settings
+from hypothesis import strategies as st
 
 from scripts.scorecards import s6_scorecards as scorecards
-from scripts.scorecards.s6_scorecards import (
-    EPSILON,
-    Measurement,
-    ScorecardError,
-    Threshold,
-)
 
 
-DECIMAL_VALUES = st.decimals(
-    min_value=-50,
-    max_value=50,
-    places=4,
-    allow_nan=False,
-    allow_infinity=False,
-)
-POSITIVE_DECIMALS = st.decimals(
-    min_value=0,
-    max_value=10,
-    places=4,
-    allow_nan=False,
-    allow_infinity=False,
-)
-
-
-def make_threshold(metric_id: str, comparison: str, target: Decimal, order: int = 1) -> Threshold:
-    return Threshold(
-        metric_id=metric_id,
-        order=order,
-        display_name=f"Metric {metric_id.upper()}",
-        comparison=comparison,
-        target_value=target,
-        unit="percent",
-        description="desc",
-        on_fail="fix",
+try:  # pragma: no branch - test environments may register the profile already
+    settings.register_profile(
+        "ci",
+        settings(
+            max_examples=50,
+            deadline=None,
+            suppress_health_check=(HealthCheck.too_slow,),
+        ),
     )
+except ValueError:
+    pass
 
 
-def make_measurement(metric_id: str, value: Decimal) -> Measurement:
-    return Measurement(
-        metric_id=metric_id,
-        value=value,
-        unit="percent",
-        sample_size=100,
-        measurement="2024-01-01/2024-01-02",
-    )
+def _freeze_now(monkeypatch: pytest.MonkeyPatch, when: datetime) -> None:
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz: timezone | None = None) -> datetime:
+            return when.astimezone(tz or timezone.utc)
+
+    monkeypatch.setattr(scorecards, "datetime", FrozenDateTime)
 
 
-@given(target=st.integers(-10, 10))
-def test_compare_gte_respects_epsilon_boundary(target: int) -> None:
-    target_decimal = Decimal(target)
-    threshold = make_threshold("m1", "gte", target_decimal)
-    within_epsilon = make_measurement("m1", target_decimal - (EPSILON / 2))
-    status, delta = scorecards.compare(threshold, within_epsilon)
-    assert status == "pass"
-    assert delta == within_epsilon.value - target_decimal
-
-    beyond_epsilon = make_measurement("m1", target_decimal - (EPSILON * 2))
-    status, _ = scorecards.compare(threshold, beyond_epsilon)
-    assert status == "fail"
-
-
-@given(target=st.integers(-10, 10))
-def test_compare_lte_respects_epsilon_boundary(target: int) -> None:
-    target_decimal = Decimal(target)
-    threshold = make_threshold("m2", "lte", target_decimal)
-    within_epsilon = make_measurement("m2", target_decimal + (EPSILON / 2))
-    status, delta = scorecards.compare(threshold, within_epsilon)
-    assert status == "pass"
-    assert delta == target_decimal - within_epsilon.value
-
-    beyond_epsilon = make_measurement("m2", target_decimal + (EPSILON * 2))
-    status, _ = scorecards.compare(threshold, beyond_epsilon)
-    assert status == "fail"
-
-
-@given(
-    target=DECIMAL_VALUES,
-    measurement_delta=DECIMAL_VALUES,
-    relax=POSITIVE_DECIMALS,
-    tighten=POSITIVE_DECIMALS,
-)
-def test_metamorphic_relax_and_tighten_gte(
-    target: Decimal,
-    measurement_delta: Decimal,
-    relax: Decimal,
-    tighten: Decimal,
-) -> None:
-    threshold = make_threshold("m3", "gte", target)
-    measurement_value = target - measurement_delta
-    measurement = make_measurement("m3", measurement_value)
-    status, _ = scorecards.compare(threshold, measurement)
-
-    relaxed_threshold = make_threshold("m3", "gte", target - relax)
-    relaxed_status, _ = scorecards.compare(relaxed_threshold, measurement)
-    if status == "pass":
-        assert relaxed_status == "pass"
-
-    tightened_threshold = make_threshold("m3", "gte", target + tighten)
-    tightened_status, _ = scorecards.compare(tightened_threshold, measurement)
-    if status == "fail":
-        assert tightened_status == "fail"
-
-
-@given(
-    target=DECIMAL_VALUES,
-    measurement_delta=DECIMAL_VALUES,
-    relax=POSITIVE_DECIMALS,
-    tighten=POSITIVE_DECIMALS,
-)
-def test_metamorphic_relax_and_tighten_lte(
-    target: Decimal,
-    measurement_delta: Decimal,
-    relax: Decimal,
-    tighten: Decimal,
-) -> None:
-    threshold = make_threshold("m4", "lte", target)
-    measurement_value = target + measurement_delta
-    measurement = make_measurement("m4", measurement_value)
-    status, _ = scorecards.compare(threshold, measurement)
-
-    relaxed_threshold = make_threshold("m4", "lte", target + relax)
-    relaxed_status, _ = scorecards.compare(relaxed_threshold, measurement)
-    if status == "pass":
-        assert relaxed_status == "pass"
-
-    tightened_threshold = make_threshold("m4", "lte", target - tighten)
-    tightened_status, _ = scorecards.compare(tightened_threshold, measurement)
-    if status == "fail":
-        assert tightened_status == "fail"
-
-
-@pytest.mark.parametrize(
-    "value, unit, expected",
-    [
-        (Decimal("99.94"), "percent", "99.9%"),
-        (Decimal("0.23456"), "ratio", "0.2346"),
-        (Decimal("12.3456"), "seconds", "12.346s"),
-        (Decimal("5"), "other", "5"),
-    ],
-)
-def test_format_value_canonical(value: Decimal, unit: str, expected: str) -> None:
-    assert scorecards.format_value(value, unit) == expected
-
-
-def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
+def _write_inputs(tmp_path: Path, *, pass_fail: tuple[bool, bool] = (True, True)) -> tuple[Path, Path]:
     thresholds = {
-        "schema_version": 1,
-        "generated_at": "2024-01-01T00:00:00Z",
-        "metrics": [
-            {
-                "id": "metric_availability",
-                "order": 1,
-                "display_name": "Availability",
-                "comparison": "gte",
-                "target_value": "99.95",
-                "unit": "percent",
-                "description": "Availability target",
-                "on_fail": "Scale the service",
-            }
-        ],
+        "version": 4,
+        "timestamp_utc": "2024-01-01T00:00:00Z",
+        "quorum_ratio_min": 0.985,
+        "failover_time_p95_s_max": 3.1,
+        "staleness_p95_s_max": 2.0,
+        "cdc_lag_p95_s_max": 1.7,
+        "divergence_pct_max": 0.5,
     }
     metrics = {
-        "schema_version": 1,
-        "collected_at": "2024-01-01T00:00:00Z",
-        "metrics": [
-            {
-                "id": "metric_availability",
-                "value": "99.97",
-                "unit": "percent",
-                "sample_size": 4800,
-                "measurement": "2024-01-01/2024-01-02",
-            }
-        ],
+        "version": 9,
+        "timestamp_utc": "2024-01-02T00:00:00Z",
+        "quorum_ratio": 0.99 if pass_fail[0] else 0.90,
+        "failover_time_p95_s": 2.0 if pass_fail[1] else 3.5,
+        "staleness_p95_s": 1.5,
+        "cdc_lag_p95_s": 1.0,
+        "divergence_pct": 0.2,
     }
+
     thresholds_path = tmp_path / "thresholds.json"
     metrics_path = tmp_path / "metrics.json"
     thresholds_path.write_text(json.dumps(thresholds), encoding="utf-8")
@@ -190,65 +61,154 @@ def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
     return thresholds_path, metrics_path
 
 
-def _freeze_datetime(monkeypatch: pytest.MonkeyPatch) -> None:
-    class FrozenDateTime(datetime):
-        @classmethod
-        def now(cls, tz: timezone | None = None) -> datetime:
-            return datetime(2024, 1, 1, 12, 0, 0, tzinfo=tz or timezone.utc)
+@given(st.decimals(min_value=0, max_value=1, places=6))
+@settings(profile="ci")
+@seed(12345)
+def test_compare_respects_epsilon_for_gte(observed: Decimal) -> None:
+    assert scorecards._compare(  # type: ignore[attr-defined]
+        observed - (scorecards.EPSILON / 2), observed, "gte"
+    )
 
-    monkeypatch.setattr(scorecards, "datetime", FrozenDateTime)
+
+@given(st.decimals(min_value=0, max_value=10, places=6))
+@settings(profile="ci")
+@seed(54321)
+def test_compare_respects_epsilon_for_lte(value: Decimal) -> None:
+    assert scorecards._compare(  # type: ignore[attr-defined]
+        value + (scorecards.EPSILON / 2), value, "lte"
+    )
 
 
-def test_generate_report_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_evaluate_metrics_pass_fail_matrix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     output_dir = tmp_path / "out"
     monkeypatch.setattr(scorecards, "OUTPUT_DIR", output_dir)
-    _freeze_datetime(monkeypatch)
-    thresholds_path, metrics_path = _write_inputs(tmp_path)
+    _freeze_now(monkeypatch, datetime(2024, 1, 1, 12, tzinfo=timezone.utc))
 
-    report_first = scorecards.generate_report(thresholds_path, metrics_path)
-    markdown_first = (output_dir / "report.md").read_text(encoding="utf-8")
-    bundle_hash_first = report_first["bundle_sha256"]
+    thresholds_path, metrics_path = _write_inputs(tmp_path, pass_fail=(True, False))
+    artifacts = scorecards.generate_report(thresholds_path, metrics_path)
 
-    report_second = scorecards.generate_report(thresholds_path, metrics_path)
-    markdown_second = (output_dir / "report.md").read_text(encoding="utf-8")
-
-    assert report_second["bundle_sha256"] == bundle_hash_first
-    assert markdown_first == markdown_second
-    assert (output_dir / "bundle.sha256").read_text(encoding="utf-8").strip() == bundle_hash_first
-    assert (output_dir / "guard_status.txt").read_text(encoding="utf-8").strip() == "PASS"
-    assert "| Métrica | Valor |" in markdown_first
+    assert artifacts.report["status"] == "FAIL"
+    failing = [metric for metric in artifacts.results if not metric.ok]
+    assert {metric.spec.key for metric in failing} == {"failover_time_p95_s"}
+    markdown = (output_dir / "report.md").read_text(encoding="utf-8")
+    assert "❌ FAIL" in markdown
+    assert (output_dir / "guard_status.txt").read_text(encoding="utf-8") == "FAIL\n"
+    pr_comment = (output_dir / "pr_comment.md").read_text(encoding="utf-8")
+    assert "- Failover Time p95 (s):" in pr_comment
 
 
-def test_generate_report_missing_thresholds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    output_dir = tmp_path / "out"
+@given(
+    base=st.decimals(min_value=0, max_value=10, places=4),
+    delta=st.decimals(min_value=0, max_value=5, places=4),
+    relax=st.decimals(min_value=0, max_value=1, places=4),
+    tighten=st.decimals(min_value=0, max_value=1, places=4),
+)
+@settings(profile="ci")
+@seed(4242)
+def test_metamorphic_threshold_adjustments(
+    base: Decimal, delta: Decimal, relax: Decimal, tighten: Decimal
+) -> None:
+    observed_gte = base - delta
+    target = base
+    status = scorecards._compare(observed_gte, target, "gte")  # type: ignore[attr-defined]
+    relaxed_status = scorecards._compare(
+        observed_gte, target - relax, "gte"
+    )  # type: ignore[attr-defined]
+    tightened_status = scorecards._compare(
+        observed_gte, target + tighten, "gte"
+    )  # type: ignore[attr-defined]
+
+    if status:
+        assert relaxed_status is True
+    else:
+        assert tightened_status is False
+
+
+def test_markdown_contains_table(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output_dir = tmp_path / "scorecards"
     monkeypatch.setattr(scorecards, "OUTPUT_DIR", output_dir)
-    _, metrics_path = _write_inputs(tmp_path)
+    _freeze_now(monkeypatch, datetime(2024, 3, 2, 18, tzinfo=timezone.utc))
 
-    with pytest.raises(ScorecardError) as exc:
-        scorecards.generate_report(tmp_path / "missing.json", metrics_path)
-    assert exc.value.code == "S6-E-MISSING"
+    paths = _write_inputs(tmp_path)
+    artifacts = scorecards.generate_report(*paths)
+    markdown = (output_dir / "report.md").read_text(encoding="utf-8")
+
+    assert "| Métrica | Observado | Alvo | Status |" in markdown
+    assert artifacts.bundle_sha256 == (output_dir / "bundle.sha256").read_text(encoding="utf-8").strip()
+    pr_comment = (output_dir / "pr_comment.md").read_text(encoding="utf-8")
+    assert "![Status](./badge.svg)" in pr_comment
 
 
-def test_generate_report_schema_violation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    output_dir = tmp_path / "out"
+@pytest.mark.parametrize(
+    "value, suffix, expected",
+    [
+        (Decimal("1.2345"), "", "1.2345"),
+        (Decimal("2.0000"), "s", "2s"),
+        (Decimal("0.100"), "%", "0.1%"),
+    ],
+)
+def test_format_decimal(value: Decimal, suffix: str, expected: str) -> None:
+    assert scorecards._format_decimal(value, suffix) == expected  # type: ignore[attr-defined]
+
+
+def test_idempotent_reruns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output_dir = tmp_path / "rerun"
     monkeypatch.setattr(scorecards, "OUTPUT_DIR", output_dir)
-    thresholds_path, metrics_path = _write_inputs(tmp_path)
-    thresholds_path.write_text(
-        json.dumps({"schema_version": 1, "generated_at": "2024-01-01T00:00:00Z"}),
+    _freeze_now(monkeypatch, datetime(2024, 4, 1, 15, tzinfo=timezone.utc))
+    paths = _write_inputs(tmp_path)
+
+    first = scorecards.generate_report(*paths)
+    first_markdown = (output_dir / "report.md").read_text(encoding="utf-8")
+    second = scorecards.generate_report(*paths)
+    second_markdown = (output_dir / "report.md").read_text(encoding="utf-8")
+
+    assert first.bundle_sha256 == second.bundle_sha256
+    assert first_markdown == second_markdown
+    assert (output_dir / "guard_status.txt").read_text(encoding="utf-8") == "PASS\n"
+
+
+def test_failure_missing_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output_dir = tmp_path / "missing"
+    monkeypatch.setattr(scorecards, "OUTPUT_DIR", output_dir)
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "timestamp_utc": "2024-01-01T00:00:00Z",
+                "quorum_ratio": 0.9,
+                "failover_time_p95_s": 1.0,
+                "staleness_p95_s": 1.0,
+                "cdc_lag_p95_s": 1.0,
+                "divergence_pct": 0.1,
+            }
+        ),
         encoding="utf-8",
     )
 
-    with pytest.raises(ScorecardError) as exc:
+    with pytest.raises(scorecards.ScorecardError) as exc:
+        scorecards.generate_report(tmp_path / "thresholds.json", metrics_path)
+    assert exc.value.code == "S6-E-MISSING"
+
+
+def test_failure_schema_violation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output_dir = tmp_path / "schema"
+    monkeypatch.setattr(scorecards, "OUTPUT_DIR", output_dir)
+    thresholds_path, metrics_path = _write_inputs(tmp_path)
+    thresholds_path.write_text(json.dumps({"version": 1}), encoding="utf-8")
+
+    with pytest.raises(scorecards.ScorecardError) as exc:
         scorecards.generate_report(thresholds_path, metrics_path)
     assert exc.value.code == "S6-E-SCHEMA"
 
 
-def test_generate_report_invalid_encoding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    output_dir = tmp_path / "out"
+def test_failure_encoding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output_dir = tmp_path / "encoding"
     monkeypatch.setattr(scorecards, "OUTPUT_DIR", output_dir)
     thresholds_path, metrics_path = _write_inputs(tmp_path)
     thresholds_path.write_bytes(b"\xff\xfe\x00invalid")
 
-    with pytest.raises(ScorecardError) as exc:
+    with pytest.raises(scorecards.ScorecardError) as exc:
         scorecards.generate_report(thresholds_path, metrics_path)
     assert exc.value.code == "S6-E-ENCODING"
+


### PR DESCRIPTION
## Summary
- rewrite the Sprint 6 scorecard generator into a single coherent implementation that produces consistent artifacts and errors with structured codes
- add Hypothesis-powered scorecard and boss-final tests to cover epsilon boundaries, metamorphic behaviours, idempotent runs, and guard propagation
- extend the scorecard and boss workflows with a clean_runner matrix and resilient PR comment fallbacks

## Testing
- python -m compileall scripts/scorecards/s6_scorecards.py tests/scorecards/test_s6_scorecards.py tests/boss_final/test_pipeline.py
- pytest tests/scorecards/test_s6_scorecards.py tests/boss_final/test_pipeline.py -q *(fails: missing hypothesis package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd7b3fd6148330bcd245ac4036fcd1