### PR TITLE
Add D6 synthetic prober Grafana dashboard and runbook

### DIFF
--- a/dashboards/grafana/d6_synthetic_prober.json
+++ b/dashboards/grafana/d6_synthetic_prober.json
@@ -1,0 +1,290 @@
+{
+  "title": "D6 — Synthetic Prober",
+  "uid": "d6-synth-prober",
+  "schemaVersion": 40,
+  "version": 1,
+  "timezone": "browser",
+  "refresh": "30s",
+  "graphTooltip": 0,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "1h"
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "env",
+        "label": "Environment",
+        "type": "query",
+        "datasource": "Prometheus",
+        "definition": "label_values(synthetic_requests_total, env)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "prod",
+          "value": "prod"
+        },
+        "query": "label_values(synthetic_requests_total, env)",
+        "regex": ""
+      },
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": "Prometheus",
+        "definition": "label_values(synthetic_requests_total{env=~\"$env\"}, service)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "trendmarket-amm",
+          "value": "trendmarket-amm"
+        },
+        "query": "label_values(synthetic_requests_total{env=~\"$env\"}, service)",
+        "regex": ""
+      },
+      {
+        "name": "route",
+        "label": "Route",
+        "type": "query",
+        "datasource": "Prometheus",
+        "definition": "label_values(synthetic_requests_total{env=~\"$env\",service=~\"$service\"}, route)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "allValue": ".*",
+        "refresh": 2,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "query": "label_values(synthetic_requests_total{env=~\"$env\",service=~\"$service\"}, route)",
+        "regex": ""
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Synthetic requests (5m rate)",
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (service, route) (rate(synthetic_requests_total{env=~\"$env\",service=~\"$service\",route=~\"$route\"}[5m]))",
+          "legendFormat": "{{service}} — {{route}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Synthetic latency p75 / p95",
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "links": [
+            {
+              "title": "Tempo traces for ${__field.labels.service} :: ${__field.labels.route}",
+              "targetBlank": true,
+              "url": "/explore?orgId=1&left=%7B%22datasource%22:%22Tempo%22,%22queries%22:[%7B%22refId%22:%22A%22,%22queryType%22:%22traceql%22,%22query%22:%22{service=\\\"${__field.labels.service}\\\",route=\\\"${__field.labels.route}\\\"}%22%7D],%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.25
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.75, sum by (service, route, le) (rate(synthetic_latency_seconds_bucket{env=~\"$env\",service=~\"$service\",route=~\"$route\"}[5m])))",
+          "legendFormat": "{{service}} — {{route}} p75"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (service, route, le) (rate(synthetic_latency_seconds_bucket{env=~\"$env\",service=~\"$service\",route=~\"$route\"}[5m])))",
+          "legendFormat": "{{service}} — {{route}} p95"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Synthetic success ratio (5m avg)",
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.99
+              },
+              {
+                "color": "green",
+                "value": 0.995
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "avg_over_time(synthetic_ok_ratio{env=~\"$env\",service=~\"$service\",route=~\"$route\"}[5m])",
+          "legendFormat": "{{service}} — {{route}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "text",
+      "title": "Trace quick links",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "options": {
+        "content": "### Tempo / Jaeger\n\n* [Pesquisar traces do prober](/explore?orgId=1&left=%7B%22datasource%22:%22Tempo%22,%22queries%22:[%7B%22refId%22:%22A%22,%22queryType%22:%22traceql%22,%22query%22:%22{service=\\\"$service\\\",route=\\\"$route\\\"}%22%7D],%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)\n* Utilize os filtros `service=$service` e `route=$route` para correlacionar com spans problemáticos.\n",
+        "mode": "markdown"
+      }
+    }
+  ]
+}

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -10,5 +10,6 @@
 | Oráculos | Quorum/TWAP failover | [`oracle-quorum-twap.md`](oracle-quorum-twap.md) |
 | Fees | Thrash / cooldown | [`fee-cooldown.md`](fee-cooldown.md) |
 | Moderação | Pausa / appeals | [`moderation-pause.md`](moderation-pause.md) |
+| Observabilidade | Synthetic prober degradado | [`synthetic-prober.md`](synthetic-prober.md) |
 
 > Consulte `ops/watchers.yml` para mapear cada hook ao runbook correspondente.

--- a/docs/runbooks/synthetic-prober.md
+++ b/docs/runbooks/synthetic-prober.md
@@ -1,0 +1,32 @@
+# Runbook — Synthetic Prober degradado
+
+## Objetivo
+Restaurar `synthetic_ok_ratio ≥ 0.99` e latência p95 ≤ 500 ms durante incidentes disparados pelo alerta `OBS_Synthetic_OK_Ratio_Low`.
+
+> Dashboard operacional: [`dashboards/grafana/d6_synthetic_prober.json`](../../dashboards/grafana/d6_synthetic_prober.json)
+
+## Detectar
+1. Abrir o painel **D6 — Synthetic Prober** (Grafana → Observabilidade → D6). Validar:
+   - Painel **Synthetic requests (5m rate)** para checar quedas abruptas de execuções.
+   - Painel **Synthetic latency p75 / p95** (com links para Tempo) para identificar rotas degradadas.
+   - Painel **Synthetic success ratio (5m avg)** para confirmar violação do limiar 0.99.
+2. Usar o link "Trace quick links" no dashboard para abrir Tempo/Jaeger já filtrado por `service=$service` e `route=$route`.
+3. Correlacionar com métricas de backend (`ops/grafana/D1-Latencia.json`) caso a latência do core também esteja elevada.
+4. Verificar erros recentes em `loki` (`{service="trendmarket-amm",route="$route"}`) para detectar timeouts/5xx.
+
+## Mitigar
+1. **Rotas específicas com erro**
+   - Aplicar _feature flag_ de _retry_ elevado: `policy_engine.sh set synthetic.max_retries=5`.
+   - Se for rota `pricing`, considerar degradar cálculo avançado (`pricing.mode=basic`).
+2. **Latência generalizada**
+   - Escalar horizontalmente o serviço `trendmarket-amm` (`kubectl scale deployment trendmarket-amm --replicas=+$N`).
+   - Reduzir carga opcional suspendendo ganchos não críticos (`ops/watchers/a110_observability.yaml` → comentar hooks `lite_mode`).
+3. **Falha externa (dependências)**
+   - Checar status dos provedores (CDC, oráculos). Se instáveis, acionar runbooks correspondentes antes de retomar o prober.
+   - Pausar prober sintético via `scripts/sim_run.sh --probe synthetic --pause` para evitar ruído enquanto a causa raiz é tratada.
+4. Validar recuperação acompanhando `synthetic_ok_ratio` ≥ 0.99 e `synthetic_latency_seconds` p95 ≤ 0.5 s por 3 janelas de 5 minutos.
+
+## Comunicação
+- Atualizar `#dec-incident` a cada 15 minutos com progresso e ETA.
+- Abrir ticket `INC-SYNTHETIC` com timeline, métricas capturadas (incluir screenshot do dashboard D6) e ações executadas.
+- Após resolução, anexar o bundle `out/obs_gatecheck/bundle.zip` à retroativa ORR.

--- a/scripts/grafana_snapshot.sh
+++ b/scripts/grafana_snapshot.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
-EVI="out/obs_gatecheck/evidence/dashboards"; mkdir -p "$EVI"
-# Sem Grafana com /render aqui, deixamos stub com lista dos JSONs presentes
-ls -1 ops/grafana/*.json > "$EVI/dashboards_list.txt" 2>/dev/null || true
+EVI="out/obs_gatecheck/evidence/dashboards"
+mkdir -p "$EVI"
+: > "$EVI/dashboards_list.txt"
+
+for dir in ops/grafana dashboards/grafana; do
+  if [ -d "$dir" ]; then
+    while IFS= read -r file; do
+      echo "$file" >> "$EVI/dashboards_list.txt"
+      dest="$EVI/$file"
+      mkdir -p "$(dirname "$dest")"
+      cp "$file" "$dest"
+    done < <(find "$dir" -maxdepth 1 -type f -name '*.json' | sort)
+  fi
+done
+
 echo SNAPSHOT_OK


### PR DESCRIPTION
## Summary
- add a Grafana dashboard for the synthetic prober with volume, latency, success ratio, and trace links panels
- document the dashboard in a dedicated synthetic prober runbook and index it in the runbook catalog
- update the Grafana snapshot script to copy dashboards from both ops and dashboards directories into the ORR evidence bundle

## Testing
- ./scripts/grafana_snapshot.sh

------
https://chatgpt.com/codex/tasks/task_e_68fd93466e488330896b27b3e88091c9