### PR TITLE
Add RUN_PROFILE modes and T9–T12 stages to ORR pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,26 @@
 │ bundle.sha256 → provenance   │ spec_check + refmap     │ hash_manifest │
 └──────────────────────────────┴─────────────────────────┴──────────┘
                  ↓                        ↓                      ↓
-            out/orr_gatecheck       PR comment DX         artifacts ORR
+            out/obs_gatecheck       PR comment DX         artifacts ORR
 ```
 
 ### Contrato do EVID (evidence directory)
 
-Precedência: **Ambiente (`EVID`)** → **Flag CLI (`--out`/`--evidence`)** → **Default** (`out/orr_gatecheck/evidence`).
+Precedência: **Ambiente (`EVID`)** → **Flag CLI (`--out`/`--evidence`)** → **Default** (`out/obs_gatecheck/evidence`).
 Todos os scripts aceitam `--out`/`--evidence` e respeitam `EVID` se definido.
 
 ## Tempo-alvo de publicação on-chain
 
 * **SLO:** publicar `merkle_root` + `bundle.sha256` em ≤ 5 minutos após `STATUS: PASS`.
 * **Fallback:** utilizar Base Sepolia em modo `--dry-run` + WORM até que `L2_ENDPOINT`/wallet estejam ativos.
-* **Procedimento real:** executar `bash scripts/provenance/publish_root.sh --evidence out/orr_gatecheck/evidence` sem `--dry-run` com as variáveis `L2_*` presentes.
+* **Procedimento real:** executar `bash scripts/provenance/publish_root.sh --evidence out/obs_gatecheck/evidence` sem `--dry-run` com as variáveis `L2_*` presentes.
 
 ## Como rodar o pipeline
 
-1. Execute localmente: `bash scripts/orr_all.sh --seed-dir seeds`.
-2. Confira `out/orr_gatecheck/evidence/spec_check.txt` (esperado `RESULT=PASS`).
-3. Inspecione `out/orr_gatecheck/evidence/analysis/index.html` para o índice de evidências (botão “Copiar comando”).
-4. O bundle completo e hashes ficam em `out/orr_gatecheck/evidence/` e `out/sim/` (SimCity fast + nightly).
+1. Execute localmente: `RUN_PROFILE=fast bash scripts/orr_all.sh --seed-dir seeds` (modo rápido) ou `RUN_PROFILE=full bash scripts/orr_all.sh --seed-dir seeds` (modo completo).
+2. Confira `out/obs_gatecheck/evidence/spec_check.txt` (esperado `RESULT=PASS`).
+3. Inspecione `out/obs_gatecheck/evidence/analysis/index.html` para o índice de evidências (botão “Copiar comando”).
+4. O bundle completo e hashes ficam em `out/obs_gatecheck/evidence/` e `out/sim/` (SimCity fast + nightly).
 
 ## CI — GitHub Actions
 

--- a/scripts/analysis/run_all.sh
+++ b/scripts/analysis/run_all.sh
@@ -48,11 +48,11 @@ INDEX_FILE="$EVID/analysis/index.html"
 
 # Se o caminho efetivo do EVID for o default "canônico", exibir caminho relativo no comando copiado
 # (melhor DX ao colar no terminal)
-_default_abs="$(cd "$DEFAULT_EVID" && pwd -P 2>/dev/null || echo "$DEFAULT_EVID")"
+_default_abs="$(cd "$DEFAULT_EVID" 2>/dev/null && pwd -P 2>/dev/null || echo "$DEFAULT_EVID")"
 _evid_abs="$(cd "$EVID" && pwd -P 2>/dev/null || echo "$EVID")"
 COMMAND_OUT="$_evid_abs"
 if [[ "$_evid_abs" == "$_default_abs" ]]; then
-  COMMAND_OUT="out/orr_gatecheck/evidence"
+  COMMAND_OUT="out/obs_gatecheck/evidence"
 fi
 
 COMMAND="bash scripts/analysis/run_all.sh --out ${COMMAND_OUT} --seed-dir seeds"

--- a/scripts/orr_all.sh
+++ b/scripts/orr_all.sh
@@ -2,10 +2,25 @@
 set -euo pipefail
 IFS=$'\n\t'; export LC_ALL=C; export TZ=UTC
 
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+RUN_PROFILE="${RUN_PROFILE:-fast}"
+case "$RUN_PROFILE" in
+  fast|full) ;;
+  *)
+    echo "[orr_all] RUN_PROFILE inválido: $RUN_PROFILE" >&2
+    echo "Use RUN_PROFILE=fast (default) ou RUN_PROFILE=full." >&2
+    exit 1
+    ;;
+esac
+
 # ── Paths base ───────────────────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"                  # repo root
-DEFAULT_EVID="$ROOT/out/orr_gatecheck/evidence"       # canônico dentro do repo
+DEFAULT_OUT="$ROOT/out/obs_gatecheck"
+DEFAULT_EVID="$DEFAULT_OUT/evidence"                  # canônico dentro do repo
 
 # Evidence precedence: Ambiente (EVID) → CLI (--out/--evidence) → Default
 EVID="${EVID:-$DEFAULT_EVID}"
@@ -44,17 +59,58 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 export EVID
+export PROFILE="$RUN_PROFILE"
+
+OUT_DIR="$(cd "$(dirname "$EVID")" && pwd)"
+LOG_DIR="$OUT_DIR/logs"
+LOG_FILE="$LOG_DIR/orr_all.txt"
 
 # ── Dirs de evidence ────────────────────────────────────────────────────────────
 mkdir -p "$EVID" \
          "$EVID/dashboards" "$EVID/analysis" "$EVID/rum" \
          "$EVID/obs_self" "$EVID/burnrate" "$EVID/hooks"
+mkdir -p "$LOG_DIR"
 
-echo "📁 Using EVID: $EVID"
-echo "🚦 Publish mode: $MODE_PUBLISH"
+: > "$LOG_FILE"
+exec > >(tee -a "$LOG_FILE")
+exec 2> >(tee -a "$LOG_FILE" >&2)
 
-# ── Etapa 1/8: análises ─────────────────────────────────────────────────────────
-printf '[orr_all] etapa 1/8 — análises\n'
+echo "[$(timestamp)] RUN_PROFILE=$RUN_PROFILE"
+echo "[$(timestamp)] 📁 Using EVID: $EVID"
+echo "[$(timestamp)] 📓 Logs: $LOG_DIR"
+echo "[$(timestamp)] 🚦 Publish mode: $MODE_PUBLISH"
+
+# ── Preflight para perfil full ─────────────────────────────────────────────────
+if [[ "$RUN_PROFILE" == "full" ]]; then
+  echo "[$(timestamp)] → Preflight cargo (fetch/build/fmt/clippy/test)"
+  if command -v cargo >/dev/null 2>&1; then
+    (
+      cd "$ROOT"
+      cargo fetch
+      cargo build
+      cargo fmt -- --check
+      cargo clippy -- -D warnings
+      cargo test
+    )
+  else
+    echo "[orr_all] cargo indisponível — pulando etapa full de build/test"
+  fi
+
+  echo "[$(timestamp)] → Preflight supply-chain (cargo deny & audit)"
+  if command -v cargo >/dev/null 2>&1 && cargo deny --help >/dev/null 2>&1; then
+    (cd "$ROOT" && cargo deny check)
+  else
+    echo "[orr_all] cargo deny indisponível — skip"
+  fi
+  if command -v cargo >/dev/null 2>&1 && cargo audit --help >/dev/null 2>&1; then
+    (cd "$ROOT" && cargo audit)
+  else
+    echo "[orr_all] cargo audit indisponível — skip"
+  fi
+fi
+
+# ── Stage: análises ────────────────────────────────────────────────────────────
+echo "[$(timestamp)] → Análises determinísticas"
 bash "$ROOT/scripts/analysis/run_all.sh" --out "$EVID" --seed-dir "$SEED_DIR"
 
 # Poster (best-effort)
@@ -65,8 +121,8 @@ else
   echo "Poster indisponível (convert ausente)" > "$EVID/dashboards/poster_a4.txt"
 fi
 
-# ── Etapa 2/8: hooks A110 (fast/real) ──────────────────────────────────────────
-printf '[orr_all] etapa 2/8 — hooks sintéticos (%s)\n' "$HOOK_MODE"
+# ── Stage: hooks A110 (fast/real) ───────────────────────────────────────────────
+echo "[$(timestamp)] → Hooks sintéticos (${HOOK_MODE})"
 HOOKS=(
   hook_invariant_breach
   hook_latency_budget
@@ -86,8 +142,8 @@ for hook in "${HOOKS[@]}"; do
   fi
 done
 
-# ── Etapa 3/8: policy engine + env dump ────────────────────────────────────────
-printf '[orr_all] etapa 3/8 — policy engine\n'
+# ── Stage: policy engine + env dump ────────────────────────────────────────────
+echo "[$(timestamp)] → Policy engine"
 bash "$ROOT/scripts/policy_engine.sh" --emit-policy-hash --out "$EVID" --seed-file "$SEED_DIR/engine/policy_metrics.json"
 python - "$SEED_DIR/engine/policy_metrics.json" "$EVID/env_dump.txt" <<'PY'
 import json, sys
@@ -99,20 +155,20 @@ with open(sys.argv[2], 'w', encoding='utf-8') as fp:
     fp.write(f"ResilienceIndexNightly: {metrics['resilience_index_nightly']}\n")
 PY
 
-# ── Etapa 4/8: simulações determinísticas ──────────────────────────────────────
-printf '[orr_all] etapa 4/8 — simulações determinísticas\n'
+# ── Stage: simulações determinísticas ──────────────────────────────────────────
+echo "[$(timestamp)] → Simulações determinísticas (fast/nightly + chaos weekly)"
 bash "$ROOT/scripts/sim_run.sh" --mode fast
 bash "$ROOT/scripts/sim_run.sh" --mode nightly
 bash "$ROOT/scripts/chaos_weekly.sh" --evidence "$EVID"
 
-# ── Etapa 5/8: bundle SHA do repo ──────────────────────────────────────────────
-printf '[orr_all] etapa 5/8 — geração do bundle SHA\n'
+# ── Stage: bundle SHA do repo ──────────────────────────────────────────────────
+echo "[$(timestamp)] → Geração do bundle SHA"
 BUNDLE_FILE="$EVID/bundle.sha256.txt"
 BUNDLE_SHA=$(git -C "$ROOT" ls-files -z | xargs -0 sha256sum | LC_ALL=C sort -k2 | sha256sum | awk '{print $1}')
 printf '%s\n' "$BUNDLE_SHA" > "$BUNDLE_FILE"
 
-# ── Etapa 6/8: governança (assinaturas + provenance) ───────────────────────────
-printf '[orr_all] etapa 6/8 — governança (assinaturas + provenance)\n'
+# ── Stage: governança (assinaturas + provenance) ───────────────────────────────
+echo "[$(timestamp)] → Governança (assinaturas + provenance)"
 bash "$ROOT/scripts/provenance/verify_signatures.sh" --evidence "$EVID"
 PUBLISH_ARGS=(--evidence "$EVID")
 if [[ "$MODE_PUBLISH" == "real" ]]; then
@@ -122,30 +178,63 @@ else
 fi
 bash "$ROOT/scripts/provenance/publish_root.sh" "${PUBLISH_ARGS[@]}"
 
-# ── Etapa 7/8: spec check ──────────────────────────────────────────────────────
-printf '[orr_all] etapa 7/8 — spec check\n'
+# ── Stage: spec check ──────────────────────────────────────────────────────────
+echo "[$(timestamp)] → Spec check"
 bash "$ROOT/scripts/spec_check.sh" --out "$EVID"
 
-# ── Etapa 8/8: manifesto de hashes ─────────────────────────────────────────────
-printf '[orr_all] etapa 8/8 — manifesto de hashes\n'
+# ── Stage: manifesto de hashes ─────────────────────────────────────────────────
+echo "[$(timestamp)] → Manifesto de hashes"
 bash "$ROOT/scripts/analysis/hash_manifest.sh" --evidence "$EVID"
 
+# ── Stages extras (RUN_PROFILE=full) ────────────────────────────────────────────
+if [[ "$RUN_PROFILE" == "full" ]]; then
+  echo "[$(timestamp)] → T9 PII Red Team"
+  bash "$ROOT/scripts/obs_sec_redteam.sh" | tee "$LOG_DIR/t9_pii.txt"
+
+  echo "[$(timestamp)] → T10 Synthetic prober"
+  bash "$ROOT/scripts/obs_probe_synthetic.sh" | tee "$LOG_DIR/t10_probe.txt"
+
+  echo "[$(timestamp)] → T11 Chaos drills"
+  bash "$ROOT/scripts/obs_chaos.sh" | tee "$LOG_DIR/t11_chaos.txt"
+
+  echo "[$(timestamp)] → T12 Costs & cardinality"
+  python3 "$ROOT/scripts/obs_cardinality_costs.py" | tee "$LOG_DIR/t12_costs.txt"
+
+  echo "[$(timestamp)] → T12 SBOM"
+  bash "$ROOT/scripts/obs_sbom.sh" | tee "$LOG_DIR/t12_sbom.txt"
+
+  echo "[$(timestamp)] → T12 Baseline perf"
+  bash "$ROOT/scripts/obs_baseline_perf.sh" | tee "$LOG_DIR/t12_baseline.txt"
+
+  echo "[$(timestamp)] → T12 Golden traces"
+  bash "$ROOT/scripts/obs_trace_golden.sh" | tee "$LOG_DIR/t12_traces.txt"
+fi
+
 # ── Sumário de arquivos chave ──────────────────────────────────────────────────
-printf '\n[orr_all] Sumário de evidências relevantes:\n'
+echo
+echo "[orr_all] Sumário de evidências relevantes:"
 for path in \
   "$EVID/spec_check.txt" \
   "$EVID/policy_hash.txt" \
   "$EVID/bundle.sha256.txt" \
   "$EVID/provenance_onchain.json" \
-  "$EVID/signatures.json"; do
+  "$EVID/signatures.json" \
+  "$EVID/costs_cardinality.json" \
+  "$EVID/sbom.cdx.json" \
+  "$EVID/baseline_perf.json" \
+  "$EVID/golden_traces.json"; do
   if [[ -f "$path" ]]; then
-    size=$(stat -c '%s' "$path")
+    if command -v stat >/dev/null 2>&1; then
+      size=$(stat -c '%s' "$path" 2>/dev/null || stat -f '%z' "$path" 2>/dev/null || echo "?")
+    else
+      size="?"
+    fi
     printf '  - %s (%s bytes)\n' "$path" "$size"
   fi
 done
 
-printf 'ACCEPTANCE_OK\n'
-printf 'GATECHECK_OK\n'
+echo 'ACCEPTANCE_OK'
+echo 'GATECHECK_OK'
 
 # ── Self-check (GO/NO-GO) ──────────────────────────────────────────────────────
 missing=()


### PR DESCRIPTION
## Summary
- update `scripts/orr_all.sh` to honor RUN_PROFILE fast/full modes, stream logs to out/obs_gatecheck, and run the T9–T12 checks with tee'd evidence logs
- adjust the analysis runner to tolerate missing legacy paths and surface the new default evidence location
- refresh the README guidance so operators run the fast/full profiles against out/obs_gatecheck

## Testing
- RUN_PROFILE=fast bash scripts/orr_all.sh --seed-dir seeds >/tmp/orr_fast.log
- RUN_PROFILE=full bash scripts/orr_all.sh --seed-dir seeds >/tmp/orr_full.log


------
https://chatgpt.com/codex/tasks/task_e_68fd934470348330a221f9a55e9badc5