### PR TITLE
Add PII labels evidence file to gatecheck bundle

### DIFF
--- a/scripts/obs_bundle_report.py
+++ b/scripts/obs_bundle_report.py
@@ -22,6 +22,7 @@ EVIDENCE_REQUIRED: Sequence[Path] = [
     Path("evidence/sbom.cdx.json"),
     Path("evidence/synthetic_probe.json"),
     Path("evidence/pii_probe.json"),
+    Path("evidence/pii_labels.ok"),
     Path("evidence/chaos_summary.json"),
     Path("evidence/baseline_perf.json"),
     Path("evidence/golden_traces.json"),

--- a/scripts/obs_sec_redteam.sh
+++ b/scripts/obs_sec_redteam.sh
@@ -3,7 +3,12 @@ set -euo pipefail
 EVI="out/obs_gatecheck/evidence"; mkdir -p "$EVI"
 echo '{"msg":"probe","email":"joao.silva+probe@example.com","cpf":"123.456.789-09"}' > "$EVI/pii_probe.json"
 if command -v gitleaks >/dev/null 2>&1 && [ -f ops/security/gitleaks.toml ]; then
-  gitleaks detect --no-git -s "$EVI" --config ops/security/gitleaks.toml --exit-code 1 || { echo PII_FAIL; exit 1; }
+  if gitleaks detect --no-git -s "$EVI" --config ops/security/gitleaks.toml --exit-code 1; then
+    printf 'LABELS_OK\n' > "$EVI/pii_labels.ok"
+  else
+    echo PII_FAIL
+    exit 1
+  fi
 else
   echo "gitleaks não encontrado ou config ausente — skip"
 fi

--- a/src/amm_obs/release.py
+++ b/src/amm_obs/release.py
@@ -76,6 +76,7 @@ def _evidence_checks(context: _Context) -> Dict[str, bool]:
         "metrics_summary": (ev / "metrics_summary.json").exists(),
         "trace_log_smoke": (ev / "trace_log_smoke.json").exists(),
         "pii_probe": (ev / "pii_probe.json").exists(),
+        "pii_labels": (ev / "pii_labels.ok").exists(),
         "synthetic_probe": (ev / "synthetic_probe.json").exists(),
         "chaos_summary": (ev / "chaos_summary.json").exists(),
         "costs_cardinality": (ev / "costs_cardinality.json").exists(),

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -89,6 +89,7 @@ class ReleaseManifestTests(unittest.TestCase):
             _write_json(
                 evidence / "pii_probe.json", {"status": "OK", "cpf": False}
             )
+            (evidence / "pii_labels.ok").write_text("LABELS_OK\n", encoding="utf-8")
             _write_json(evidence / "chaos_summary.json", {"status": "GREEN"})
             _write_json(evidence / "baseline_perf.json", {"qps": 125})
             _write_json(evidence / "golden_traces.json", {"spans": 4})
@@ -108,6 +109,7 @@ class ReleaseManifestTests(unittest.TestCase):
             self.assertTrue(manifest["evidence_checks"]["metrics_summary"])
             self.assertEqual(manifest["synthetic_probe"]["ok_ratio"], 1.0)
             self.assertEqual(manifest["watchers"]["alerts_count"], 1)
+            self.assertTrue(manifest["evidence_checks"]["pii_labels"])
             self.assertEqual(
                 manifest["drills"]["trace_log_smoke"]["observability_level"],
                 "full",


### PR DESCRIPTION
## Summary
- add a LABELS_OK marker when the gitleaks deny-list scan succeeds
- treat pii_labels.ok as required evidence in the bundle and release manifest checks
- update the release manifest test fixture to include the new evidence file

## Testing
- PYTHONPATH=src pytest tests/test_release_manifest.py *(fails: existing TypeError in _write_json helper signature)*

------
https://chatgpt.com/codex/tasks/task_e_68fd9ae7d654833093658f20f5ca368a