### PR TITLE
Fix YAML errors in Q1 Boss Final workflow

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -42,7 +42,6 @@ jobs:
   stage:
     name: Stage ${{ matrix.stage }} (clean=${{ matrix.clean_runner }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -93,48 +92,6 @@ jobs:
         with:
           name: boss-stage-${{ matrix.stage }}
           path: out/q1_boss_final/stages/${{ matrix.stage }}
-
-  boss:
-    needs: stage
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      REPORT_DIR: out/q1_boss_final
-            pytest==8.3.3 \
-            hypothesis==6.103.0 \
-            yamllint==1.35.1 \
-            jsonschema==4.23.0
-
-      - name: Execute sprint guard
-        id: stage
-        timeout-minutes: 12
-        run: |
-          set -euo pipefail
-          if [ "${{ matrix.clean_runner }}" = "true" ]; then
-            variant="clean"
-          else
-            variant="primary"
-          fi
-          echo "variant=$variant" >> "$GITHUB_OUTPUT"
-          python scripts/boss_final/sprint_guard.py --stage "$STAGE" --variant "$variant"
-
-      - name: Upload guard bundle
-        if: always()
-        uses: actions/upload-artifact@89ef406dd8d7e03cde85f3b4a7a6b5483c8f8c7a
-        with:
-          name: q1-boss-final-${{ matrix.stage }}-${{ steps.stage.outputs.variant }}
-          path: out/q1_boss_final/stages/${{ matrix.stage }}/${{ steps.stage.outputs.variant }}
-          if-no-files-found: error
-
-      - name: Enforce guard status
-        if: ${{ always() && steps.stage.outcome == 'success' }}
-        run: |
-          status=$(cat out/q1_boss_final/stages/${{ matrix.stage }}/${{ steps.stage.outputs.variant }}/guard_status.txt)
-          if [ "$status" != "PASS" ]; then
-            echo "stage_guard=$status" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
   aggregate:
     name: Aggregate Boss Final
     needs: stage
@@ -142,6 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
+      REPORT_DIR: out/q1_boss_final
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
     steps:
       - name: Checkout
@@ -203,60 +161,30 @@ jobs:
           path: out/q1_boss_final/stages/s6
 
       - name: Aggregate Q1 boss report
+        id: aggregate
+        continue-on-error: true
         timeout-minutes: 5
         run: python scripts/boss_final/aggregate_q1.py
 
       - name: Upload artifacts
+        if: always()
         uses: actions/upload-artifact@89ef406dd8d7e03cde85f3b4a7a6b5483c8f8c7a
         with:
           name: q1-boss-final
           path: ${{ env.REPORT_DIR }}
 
       - name: Validate report schema
+        if: always()
         run: python -m jsonschema --instance "$REPORT_DIR/report.json" --schema schemas/q1_boss_report.schema.json
 
       - name: Evaluate guard status
         id: guard
         run: |
           status=$(cat "$REPORT_DIR/guard_status.txt")
-          echo "guard_status=$status" >> $GITHUB_OUTPUT
+          echo "guard_status=$status" >> "$GITHUB_OUTPUT"
           if [ "$status" != "PASS" ]; then
             exit 1
           fi
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-      - name: Download stage bundles
-        if: always()
-        uses: actions/download-artifact@9bc31d1110da1a34f4cfcc1c4dfd4ad73752c86f
-        with:
-          pattern: q1-boss-final-*
-          path: out/q1_boss_final/stages
-          merge-multiple: true
-
-      - name: Aggregate stages
-        id: aggregate
-        continue-on-error: true
-        timeout-minutes: 12
-        run: |
-          set -euo pipefail
-          if [ -n "$RELEASE_TAG" ]; then
-            python scripts/boss_final/aggregate_q1.py --release-tag "$RELEASE_TAG"
-          else
-            python scripts/boss_final/aggregate_q1.py
-          fi
-
-      - name: Validate aggregated report schema
-        if: always()
-        timeout-minutes: 3
-        run: python -m jsonschema --instance out/q1_boss_final/report.json --schema schemas/q1_boss_report.schema.json
-
-      - name: Upload aggregate bundle
-        if: always()
-        uses: actions/upload-artifact@89ef406dd8d7e03cde85f3b4a7a6b5483c8f8c7a
-        with:
-          name: q1-boss-final-aggregate
-          path: out/q1_boss_final
 
       - name: Publish Boss Final summary
         if: always()
@@ -265,29 +193,10 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const reportDir = process.env.REPORT_DIR;
+            const fallback = '⚠️ Relatório não encontrado. Veja GITHUB_STEP_SUMMARY para detalhes.';
+            const reportDir = process.env.REPORT_DIR || path.join(process.cwd(), 'out', 'q1_boss_final');
             const commentPath = path.join(reportDir, 'pr_comment.md');
-            let body = '⚠️ Relatório não encontrado. Veja GITHUB_STEP_SUMMARY para detalhes.';
-            if (fs.existsSync(commentPath)) {
-              body = fs.readFileSync(commentPath, 'utf8');
-            }
-            core.summary.addHeading('Q1 Boss Final');
-            core.summary.addRaw(body);
-            await core.summary.write();
-            try {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body
-              });
-            } catch (error) {
-              core.warning(`Falha ao comentar no PR: ${error.message}`);
-            }
-            const base = path.join(process.cwd(), 'out', 'q1_boss_final');
-            const commentPath = path.join(base, 'pr_comment.md');
-            let body = '⚠️ Relatório não encontrado. Veja GITHUB_STEP_SUMMARY para detalhes.';
-
+            let body = fallback;
             try {
               if (fs.existsSync(commentPath)) {
                 body = fs.readFileSync(commentPath, 'utf8');
@@ -295,33 +204,21 @@ jobs:
             } catch (error) {
               core.warning(`Falha ao ler pr_comment.md: ${error.message}`);
             }
-
-            const writeSummary = async () => {
+            core.summary.addHeading('Q1 Boss Final');
+            core.summary.addRaw(body);
+            core.summary.addEOL();
+            await core.summary.write();
+            if (context.eventName === 'pull_request') {
               try {
-                core.summary.addHeading('Q1 Boss Final');
-                core.summary.addRaw(body);
-                core.summary.addEOL();
-                await core.summary.write();
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body,
+                });
               } catch (error) {
-                core.warning(`Falha ao escrever summary: ${error.message}`);
+                core.warning(`Falha ao comentar no PR: ${error.message}`);
               }
-            };
-
-            try {
-              if (context.eventName === 'pull_request') {
-                try {
-                  await github.rest.issues.createComment({
-                    issue_number: context.issue.number,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    body,
-                  });
-                } catch (error) {
-                  core.warning(`Falha ao comentar no PR: ${error.message}`);
-                }
-              }
-            } finally {
-              await writeSummary();
             }
 
       - name: Enforce aggregate status


### PR DESCRIPTION
## Summary
- remove the incomplete `boss` job section that broke the workflow syntax
- streamline the aggregate stage to reuse the existing artifact downloads and summary publication logic
- ensure shared environment variables (like `REPORT_DIR`) are defined for the aggregate job

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68fdc5744db08330835a04cac09409a5