### PR TITLE
Fix checkout action references for boss workflows

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -53,7 +53,7 @@ jobs:
       CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7
@@ -103,7 +103,7 @@ jobs:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -45,7 +45,7 @@ jobs:
       CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7


### PR DESCRIPTION
## Summary
- replace the invalid pinned commit for `actions/checkout` in the boss workflows with the maintained v4 tag

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fdc9704a508330ab65dcd046f3cb74