### PR TITLE
Replace setup-python action with manual Python install

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -55,11 +55,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7
-        with:
-          python-version: '3.11'
-          cache: 'pip'
+      - name: Install Python 3.11
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+          python -m ensurepip --upgrade
 
       - name: Upgrade packaging toolchain
         timeout-minutes: 5
@@ -105,11 +106,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7
-        with:
-          python-version: '3.11'
-          cache: 'pip'
+      - name: Install Python 3.11
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+          python -m ensurepip --upgrade
 
       - name: Upgrade packaging toolchain
         timeout-minutes: 5

--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -58,7 +58,10 @@ jobs:
       - name: Install Python 3.11
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils python3.11-dev
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
           python -m ensurepip --upgrade
 
@@ -109,7 +112,10 @@ jobs:
       - name: Install Python 3.11
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils python3.11-dev
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
           python -m ensurepip --upgrade
 

--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -62,7 +62,10 @@ jobs:
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update
           sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils python3.11-dev
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 400
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 400
+          sudo update-alternatives --set python3 /usr/bin/python3.11
+          sudo update-alternatives --set python /usr/bin/python3.11
           python -m ensurepip --upgrade
 
       - name: Upgrade packaging toolchain
@@ -116,7 +119,10 @@ jobs:
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update
           sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils python3.11-dev
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 400
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 400
+          sudo update-alternatives --set python3 /usr/bin/python3.11
+          sudo update-alternatives --set python /usr/bin/python3.11
           python -m ensurepip --upgrade
 
       - name: Upgrade packaging toolchain

--- a/.github/workflows/s5-validation.yml
+++ b/.github/workflows/s5-validation.yml
@@ -23,7 +23,10 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils python3.11-dev
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
           python -m ensurepip --upgrade
 

--- a/.github/workflows/s5-validation.yml
+++ b/.github/workflows/s5-validation.yml
@@ -27,7 +27,10 @@ jobs:
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update
           sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils python3.11-dev
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 400
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 400
+          sudo update-alternatives --set python3 /usr/bin/python3.11
+          sudo update-alternatives --set python /usr/bin/python3.11
           python -m ensurepip --upgrade
 
       - name: Install dependencies

--- a/.github/workflows/s5-validation.yml
+++ b/.github/workflows/s5-validation.yml
@@ -19,13 +19,13 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
+      - name: Install Python 3.11
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+          python -m ensurepip --upgrade
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -47,11 +47,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7
-        with:
-          python-version: '3.11'
-          cache: 'pip'
+      - name: Install Python 3.11
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+          python -m ensurepip --upgrade
 
       - name: Upgrade packaging toolchain
         run: |

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Install Python 3.11
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils python3.11-dev
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
           python -m ensurepip --upgrade
 

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -54,7 +54,10 @@ jobs:
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update
           sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils python3.11-dev
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 400
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 400
+          sudo update-alternatives --set python3 /usr/bin/python3.11
+          sudo update-alternatives --set python /usr/bin/python3.11
           python -m ensurepip --upgrade
 
       - name: Upgrade packaging toolchain

--- a/actions.lock
+++ b/actions.lock
@@ -4,11 +4,6 @@ actions:
     date: 2024-09-15
     author: GitHub Actions
     rationale: Versão 4.1.0 auditada para hardening de fetch determinístico.
-  actions/setup-python:
-    sha: 57ded73d95736b4867d21e0da0f2e054fea0f6e7
-    date: 2024-09-15
-    author: GitHub Actions
-    rationale: Garante Python 3.11 com cache de pip e mitigação de supply-chain.
   actions/upload-artifact:
     sha: 89ef406dd8d7e03cde85f3b4a7a6b5483c8f8c7a
     date: 2024-09-15
@@ -25,12 +20,6 @@ actions:
     "date": "2024-09-15",
     "author": "GitHub Actions",
     "rationale": "Checkout with hardened fetch for deterministic builds."
-  },
-  "actions/setup-python": {
-    "sha": "57ded73d95736b4867d21e0da0f2e054fea0f6e7",
-    "date": "2024-09-15",
-    "author": "GitHub Actions",
-    "rationale": "Python 3.11 with pip cache and supply-chain guards."
   },
   "actions/github-script": {
     "sha": "11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3",


### PR DESCRIPTION
## Summary
- replace usages of actions/setup-python with explicit apt-based Python 3.11 installation across validation workflows
- update the validation workflows to rely on the locally provisioned interpreter instead of the removed action
- remove the unused setup-python entry from actions.lock

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fdce8020fc8330b78da100321bfca3