### PR TITLE
Fix GitHub Actions artifact action references

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload guard artifacts
         if: ${{ !matrix.clean_runner }}
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@v4
         with:
           name: boss-stage-${{ matrix.stage }}
           path: out/q1_boss_final/stages/${{ matrix.stage }}
@@ -139,37 +139,37 @@ jobs:
             jsonschema==4.23.0
 
       - name: Download stage artifacts
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@v4
         with:
           name: boss-stage-s1
           path: out/q1_boss_final/stages/s1
 
       - name: Download stage artifacts s2
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@v4
         with:
           name: boss-stage-s2
           path: out/q1_boss_final/stages/s2
 
       - name: Download stage artifacts s3
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@v4
         with:
           name: boss-stage-s3
           path: out/q1_boss_final/stages/s3
 
       - name: Download stage artifacts s4
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@v4
         with:
           name: boss-stage-s4
           path: out/q1_boss_final/stages/s4
 
       - name: Download stage artifacts s5
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@v4
         with:
           name: boss-stage-s5
           path: out/q1_boss_final/stages/s5
 
       - name: Download stage artifacts s6
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@v4
         with:
           name: boss-stage-s6
           path: out/q1_boss_final/stages/s6
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@v4
         with:
           name: q1-boss-final
           path: ${{ env.REPORT_DIR }}

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -206,7 +206,7 @@ jobs:
         run: python scripts/scorecards/s6_scorecards.py
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@v4
         with:
           name: s6-scorecards
           path: ${{ env.REPORT_DIR }}


### PR DESCRIPTION
## Summary
- replace invalid pinned revisions of upload-artifact/download-artifact with the maintained v4 tag
- ensure boss final and s6 workflows can upload and download artifacts again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe7b20dafc8330b38dfc0058c86d29