### PR TITLE
Replace github-script usage with local action and pin GitHub actions

### DIFF
--- a/.github/actions/github-script/action.yml
+++ b/.github/actions/github-script/action.yml
@@ -1,0 +1,10 @@
+name: Local GitHub Script
+description: Run inline JavaScript with minimal GitHub context.
+author: TrendMarket Automation Team
+inputs:
+  script:
+    description: JavaScript to execute.
+    required: true
+runs:
+  using: node20
+  main: index.js

--- a/.github/actions/github-script/index.js
+++ b/.github/actions/github-script/index.js
@@ -1,0 +1,164 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { createRequire } = require('node:module');
+
+const inputScript = process.env['INPUT_SCRIPT'];
+
+if (!inputScript || !inputScript.trim()) {
+  console.error('Input "script" is required.');
+  process.exit(1);
+}
+
+const summaryPath = process.env['GITHUB_STEP_SUMMARY'];
+const token = process.env['GITHUB_TOKEN'];
+const repoEnv = process.env['GITHUB_REPOSITORY'] || '';
+const eventName = process.env['GITHUB_EVENT_NAME'] || '';
+const eventPath = process.env['GITHUB_EVENT_PATH'];
+
+let owner = '';
+let repo = '';
+if (repoEnv.includes('/')) {
+  [owner, repo] = repoEnv.split('/', 2);
+}
+
+let eventPayload = {};
+if (eventPath && fs.existsSync(eventPath)) {
+  try {
+    const raw = fs.readFileSync(eventPath, 'utf8');
+    eventPayload = JSON.parse(raw);
+  } catch (error) {
+    console.warn(`Unable to parse event payload: ${error.message}`);
+  }
+}
+
+const resolveIssueNumber = () => {
+  if (!eventPayload || typeof eventPayload !== 'object') {
+    return undefined;
+  }
+  if (eventPayload.issue && typeof eventPayload.issue.number === 'number') {
+    return eventPayload.issue.number;
+  }
+  if (eventPayload.pull_request && typeof eventPayload.pull_request.number === 'number') {
+    return eventPayload.pull_request.number;
+  }
+  if (typeof eventPayload.number === 'number') {
+    return eventPayload.number;
+  }
+  return undefined;
+};
+
+const defaultIssueNumber = resolveIssueNumber();
+
+const summaryBuffer = [];
+
+const summary = {
+  addHeading(text, level = 1) {
+    const headingLevel = Math.max(1, Number(level) || 1);
+    summaryBuffer.push(`${'#'.repeat(headingLevel)} ${text}\n`);
+    return this;
+  },
+  addRaw(text) {
+    summaryBuffer.push(String(text));
+    return this;
+  },
+  addEOL() {
+    summaryBuffer.push('\n');
+    return this;
+  },
+  async write(options = {}) {
+    if (!summaryPath) {
+      console.warn('GITHUB_STEP_SUMMARY is not defined.');
+      summaryBuffer.length = 0;
+      return this;
+    }
+    const content = summaryBuffer.join('');
+    summaryBuffer.length = 0;
+    const flag = options.overwrite ? 'w' : 'a';
+    await fs.promises.mkdir(path.dirname(summaryPath), { recursive: true }).catch(() => undefined);
+    await fs.promises.writeFile(summaryPath, content, { encoding: 'utf8', flag });
+    return this;
+  },
+};
+
+const core = {
+  warning(message) {
+    console.warn(message);
+  },
+  summary,
+};
+
+const github = {
+  rest: {
+    issues: {
+      async createComment({ owner: inputOwner, repo: inputRepo, issue_number, body }) {
+        const resolvedOwner = inputOwner || owner;
+        const resolvedRepo = inputRepo || repo;
+        const resolvedIssue = typeof issue_number === 'number' ? issue_number : defaultIssueNumber;
+
+        if (!token) {
+          throw new Error('GITHUB_TOKEN is required to create comments.');
+        }
+        if (!resolvedOwner || !resolvedRepo || !resolvedIssue) {
+          throw new Error('Repository owner, name, or issue number missing for comment.');
+        }
+        const response = await fetch(`https://api.github.com/repos/${resolvedOwner}/${resolvedRepo}/issues/${resolvedIssue}/comments`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/vnd.github+json',
+            'Content-Type': 'application/json',
+            'User-Agent': 'trendmarketv2-local-github-script',
+          },
+          body: JSON.stringify({ body: String(body ?? '') }),
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.text().catch(() => '');
+          throw new Error(`Failed to create comment: ${response.status} ${response.statusText} ${errorBody}`.trim());
+        }
+
+        return response.json();
+      },
+    },
+  },
+};
+
+const context = {
+  eventName,
+  repo: { owner, repo },
+  issue: { number: defaultIssueNumber },
+};
+
+const sandboxRequire = createRequire(__filename);
+const sandbox = {
+  require: sandboxRequire,
+  module: { exports: {} },
+  exports: {},
+  core,
+  github,
+  context,
+  console,
+  process,
+  __filename,
+  __dirname: __dirname,
+  Buffer,
+  setTimeout,
+  setInterval,
+  clearTimeout,
+  clearInterval,
+};
+
+(async () => {
+  const wrapped = `(async () => {\n${inputScript}\n})()`;
+  const script = new vm.Script(wrapped, { filename: 'workflow-script.js' });
+  try {
+    const result = script.runInNewContext(sandbox, { timeout: 0 });
+    if (result && typeof result.then === 'function') {
+      await result;
+    }
+  } catch (error) {
+    console.error(error && error.stack ? error.stack : String(error));
+    process.exitCode = 1;
+  }
+})();

--- a/.github/workflows/_crd-orr.yml
+++ b/.github/workflows/_crd-orr.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
 
 
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload ORR bundle
 
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: obs-bundle-${{ inputs.profile }}-${{ inputs.environment }}
           path: |

--- a/.github/workflows/_mbp-s2-orr.yml
+++ b/.github/workflows/_mbp-s2-orr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
 
       - name: Tooling versions
         shell: bash
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Publicar artefatos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: orr-evidence
           path: out/orr_gatecheck/evidence
@@ -88,7 +88,7 @@ jobs:
 
       - name: Comentário no PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: ./.github/actions/github-script
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/_mbp-s3-orr.yml
+++ b/.github/workflows/_mbp-s3-orr.yml
@@ -7,7 +7,7 @@ jobs:
   orr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
       - name: Tooling versions
         run: |
           bash --version | head -n1 || true
@@ -36,7 +36,7 @@ jobs:
             echo "FREEZE=NO — ok para prosseguir"
           fi
       - name: Publicar artefatos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: s3-evidence
           path: out/s3_gatecheck/evidence
@@ -45,7 +45,7 @@ jobs:
           find out/s3_gatecheck/evidence -maxdepth 1 -type f -printf "%f %s bytes\n" | sort
       - name: Comentário no PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: ./.github/actions/github-script
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/_run-s3-command.yml
+++ b/.github/workflows/_run-s3-command.yml
@@ -10,7 +10,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
       - run: sudo apt-get update && sudo apt-get install -y python3 jq
       - run: |
           set -euo pipefail
@@ -19,7 +19,7 @@ jobs:
           eval ${{ github.event.inputs.cmd }} | tee /tmp/cmd.out
           echo "---"
           echo "Conteúdo de out/s3_gatecheck:"; ls -la out/s3_gatecheck || true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: s3-run-output
           path: |

--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
         with:
           ref: ${{ inputs.ref || github.sha }}
 
@@ -198,7 +198,7 @@ jobs:
 
       - name: Security | Upload findings
         if: ${{ always() && inputs.run_security }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: security-findings
           path: out/security/**
@@ -346,7 +346,7 @@ jobs:
           exit "$RC"
 
       - name: Upload TLA report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         if: ${{ always() && inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' }}
         with:
           name: tla-report
@@ -485,7 +485,7 @@ jobs:
 
       - name: Upload dbt docs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: s4-dbt-docs
           path: analytics/dbt/target
@@ -493,7 +493,7 @@ jobs:
 
       - name: Upload bundle
         if: ${{ always() && !inputs.run_tla }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: s5-bundle
           path: |
@@ -506,7 +506,7 @@ jobs:
 
       - name: Upload auditoria pip
         if: ${{ always() && !inputs.run_tla }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: pip-audit
           path: out/pip-audit
@@ -514,7 +514,7 @@ jobs:
 
       - name: Upload s5-orr evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: s5-orr-evidence
           path: |

--- a/.github/workflows/canary-sampler.yml
+++ b/.github/workflows/canary-sampler.yml
@@ -4,7 +4,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
       - name: Sample 100 users
         shell: bash
         run: |

--- a/.github/workflows/crd-epic-plan.yml
+++ b/.github/workflows/crd-epic-plan.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
 
       - name: Resolver inputs (IssueOps)
         id: io
@@ -97,7 +97,7 @@ jobs:
           echo "PLAN_OK"
 
       - name: Publicar artefatos (plan)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: crd-epic-plan-${{ github.ref_name }}-${{ github.run_id }}
           path: ${{ steps.io.outputs.out_dir }}/

--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -53,7 +53,7 @@ jobs:
       CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
 
       - name: Install Python 3.11
         run: |
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload guard artifacts
         if: ${{ !matrix.clean_runner }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: boss-stage-${{ matrix.stage }}
           path: out/q1_boss_final/stages/${{ matrix.stage }}
@@ -110,7 +110,7 @@ jobs:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
 
       - name: Install Python 3.11
         run: |
@@ -139,37 +139,37 @@ jobs:
             jsonschema==4.23.0
 
       - name: Download stage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
         with:
           name: boss-stage-s1
           path: out/q1_boss_final/stages/s1
 
       - name: Download stage artifacts s2
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
         with:
           name: boss-stage-s2
           path: out/q1_boss_final/stages/s2
 
       - name: Download stage artifacts s3
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
         with:
           name: boss-stage-s3
           path: out/q1_boss_final/stages/s3
 
       - name: Download stage artifacts s4
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
         with:
           name: boss-stage-s4
           path: out/q1_boss_final/stages/s4
 
       - name: Download stage artifacts s5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
         with:
           name: boss-stage-s5
           path: out/q1_boss_final/stages/s5
 
       - name: Download stage artifacts s6
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
         with:
           name: boss-stage-s6
           path: out/q1_boss_final/stages/s6
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: q1-boss-final
           path: ${{ env.REPORT_DIR }}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Publish Boss Final summary
         if: always()
-        uses: actions/github-script@11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
+        uses: ./.github/actions/github-script
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
         with:
           fetch-depth: 0
 
@@ -24,7 +24,7 @@ jobs:
 
       - name: Upload guard report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: repo-guard-report
           path: out/repo_guard/**/*.txt

--- a/.github/workflows/s5-validation.yml
+++ b/.github/workflows/s5-validation.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
         with:
           ref: ${{ inputs.ref || github.sha }}
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Sprint 5 artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: sprint5-validation-artifacts
           path: |

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -45,7 +45,7 @@ jobs:
       CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
 
       - name: Install Python 3.11
         run: |
@@ -206,7 +206,7 @@ jobs:
         run: python scripts/scorecards/s6_scorecards.py
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
         with:
           name: s6-scorecards
           path: ${{ env.REPORT_DIR }}
@@ -234,7 +234,7 @@ jobs:
 
       - name: Publish scorecard summary
         if: always()
-        uses: actions/github-script@11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
+        uses: ./.github/actions/github-script
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/shadow-toggle.yml
+++ b/.github/workflows/shadow-toggle.yml
@@ -19,7 +19,7 @@ jobs:
   toggle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
       - name: Atualizar configs/shadow.env
         run: |
           mkdir -p configs

--- a/actions.lock
+++ b/actions.lock
@@ -1,36 +1,9 @@
-actions:
-  actions/checkout:
-    sha: b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
-    date: 2024-09-15
-    author: GitHub Actions
-    rationale: Versão 4.1.0 auditada para hardening de fetch determinístico.
-  actions/upload-artifact:
-    sha: a8a3bc47d66b9b4ade100e3f1920993de94506ee
-    date: 2025-10-26
-    author: GitHub Actions
-    rationale: Atualização com hardening de expiração de token e logs ampliados.
-  actions/download-artifact:
-    sha: 8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
-    date: 2025-10-26
-    author: GitHub Actions
-    rationale: Correção de vulnerabilidade de path traversal na recuperação de artefatos.
-  actions/github-script:
-    sha: 11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3
-    date: 2024-09-15
-    author: GitHub Actions
-    rationale: Comentário de PR com fallback para GITHUB_STEP_SUMMARY.
 {
   "actions/checkout": {
     "sha": "b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6",
     "date": "2024-09-15",
     "author": "GitHub Actions",
     "rationale": "Checkout with hardened fetch for deterministic builds."
-  },
-  "actions/github-script": {
-    "sha": "11c33d7e17af65c2f8f5c38bf6e8f1525ba9a4d3",
-    "date": "2024-09-15",
-    "author": "GitHub Actions",
-    "rationale": "Comment automation with fallback warnings."
   },
   "actions/upload-artifact": {
     "sha": "a8a3bc47d66b9b4ade100e3f1920993de94506ee",


### PR DESCRIPTION
## Summary
- add a local Node action that executes inline GitHub scripts and preserves summary/comment behaviour
- point workflows at the local action and update checkout/upload/download artifacts to locked SHAs
- convert `actions.lock` into canonical JSON aligned with the pinned actions

## Testing
- pytest tests/boss_final/test_sprint_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68fe7d6b68c8833080ec409764f53075