### PR TITLE
Update actions/checkout pin to working commit

### DIFF
--- a/.github/workflows/_crd-orr.yml
+++ b/.github/workflows/_crd-orr.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
 
 
 

--- a/.github/workflows/_mbp-s2-orr.yml
+++ b/.github/workflows/_mbp-s2-orr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
 
       - name: Tooling versions
         shell: bash

--- a/.github/workflows/_mbp-s3-orr.yml
+++ b/.github/workflows/_mbp-s3-orr.yml
@@ -7,7 +7,7 @@ jobs:
   orr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+      - uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
       - name: Tooling versions
         run: |
           bash --version | head -n1 || true

--- a/.github/workflows/_run-s3-command.yml
+++ b/.github/workflows/_run-s3-command.yml
@@ -10,7 +10,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+      - uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
       - run: sudo apt-get update && sudo apt-get install -y python3 jq
       - run: |
           set -euo pipefail

--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
         with:
           ref: ${{ inputs.ref || github.sha }}
 

--- a/.github/workflows/canary-sampler.yml
+++ b/.github/workflows/canary-sampler.yml
@@ -4,7 +4,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+      - uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
       - name: Sample 100 users
         shell: bash
         run: |

--- a/.github/workflows/crd-epic-plan.yml
+++ b/.github/workflows/crd-epic-plan.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+      - uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
 
       - name: Resolver inputs (IssueOps)
         id: io

--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -53,7 +53,7 @@ jobs:
       CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
 
       - name: Install Python 3.11
         run: |
@@ -110,7 +110,7 @@ jobs:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
 
       - name: Install Python 3.11
         run: |

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
         with:
           fetch-depth: 0
 

--- a/.github/workflows/s5-validation.yml
+++ b/.github/workflows/s5-validation.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
         with:
           ref: ${{ inputs.ref || github.sha }}
 

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -45,7 +45,7 @@ jobs:
       CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+        uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
 
       - name: Install Python 3.11
         run: |

--- a/.github/workflows/shadow-toggle.yml
+++ b/.github/workflows/shadow-toggle.yml
@@ -19,7 +19,7 @@ jobs:
   toggle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6
+      - uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d
       - name: Atualizar configs/shadow.env
         run: |
           mkdir -p configs

--- a/actions.lock
+++ b/actions.lock
@@ -1,7 +1,7 @@
 {
   "actions/checkout": {
-    "sha": "b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6",
-    "date": "2024-09-15",
+    "sha": "9bb56186c3b3904c0d7bf6008d63fb09d019f64d",
+    "date": "2024-11-12",
     "author": "GitHub Actions",
     "rationale": "Checkout with hardened fetch for deterministic builds."
   },

--- a/tests/boss_final/test_sprint_guard.py
+++ b/tests/boss_final/test_sprint_guard.py
@@ -83,7 +83,7 @@ def test_validate_actions_lock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     base = tmp_path
     actions_lock = {
         "actions/checkout": {
-            "sha": "b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6",
+            "sha": "9bb56186c3b3904c0d7bf6008d63fb09d019f64d",
             "date": "2024-09-15",
             "author": "GitHub Actions",
             "rationale": "Checkout",
@@ -102,7 +102,7 @@ def test_validate_actions_lock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
                 "  build:",
                 "    runs-on: ubuntu-latest",
                 "    steps:",
-                "      - uses: actions/checkout@b4ffde65f46336ab3f3460e4f9d6a7152fb7a3b6",
+                "      - uses: actions/checkout@9bb56186c3b3904c0d7bf6008d63fb09d019f64d",
             ]
         ),
         encoding="utf-8",


### PR DESCRIPTION
## Summary
- rotate the `actions/checkout` pin to commit 9bb56186c3b3904c0d7bf6008d63fb09d019f64d across all workflows and actions.lock
- refresh the sprint guard test fixture to expect the new checkout pin

## Testing
- pytest tests/boss_final/test_sprint_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68fe8057bdac8330949bbce397f4b520