### PR TITLE
Normalize GitHub action pins to compat SHAs

### DIFF
--- a/.github/workflows/_crd-orr.yml
+++ b/.github/workflows/_crd-orr.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload ORR bundle
 
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: obs-bundle-${{ inputs.profile }}-${{ inputs.environment }}
           path: |

--- a/.github/workflows/_mbp-s2-orr.yml
+++ b/.github/workflows/_mbp-s2-orr.yml
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Publicar artefatos
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: orr-evidence
           path: out/orr_gatecheck/evidence

--- a/.github/workflows/_mbp-s3-orr.yml
+++ b/.github/workflows/_mbp-s3-orr.yml
@@ -36,7 +36,7 @@ jobs:
             echo "FREEZE=NO — ok para prosseguir"
           fi
       - name: Publicar artefatos
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: s3-evidence
           path: out/s3_gatecheck/evidence

--- a/.github/workflows/_run-s3-command.yml
+++ b/.github/workflows/_run-s3-command.yml
@@ -19,7 +19,7 @@ jobs:
           eval ${{ github.event.inputs.cmd }} | tee /tmp/cmd.out
           echo "---"
           echo "Conteúdo de out/s3_gatecheck:"; ls -la out/s3_gatecheck || true
-      - uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+      - uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: s3-run-output
           path: |

--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Security | Upload findings
         if: ${{ always() && inputs.run_security }}
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: security-findings
           path: out/security/**
@@ -262,7 +262,7 @@ jobs:
 
       - name: GHCR login (opcional)
         if: ${{ inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' && steps.ghcr_tok.outputs.has_token == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@f4ef339be1f7c0066db2ed1d1c637d705d7d76e8
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -346,7 +346,7 @@ jobs:
           exit "$RC"
 
       - name: Upload TLA report
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         if: ${{ always() && inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' }}
         with:
           name: tla-report
@@ -485,7 +485,7 @@ jobs:
 
       - name: Upload dbt docs
         if: ${{ always() }}
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: s4-dbt-docs
           path: analytics/dbt/target
@@ -493,7 +493,7 @@ jobs:
 
       - name: Upload bundle
         if: ${{ always() && !inputs.run_tla }}
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: s5-bundle
           path: |
@@ -506,7 +506,7 @@ jobs:
 
       - name: Upload auditoria pip
         if: ${{ always() && !inputs.run_tla }}
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: pip-audit
           path: out/pip-audit
@@ -514,7 +514,7 @@ jobs:
 
       - name: Upload s5-orr evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: s5-orr-evidence
           path: |

--- a/.github/workflows/crd-epic-plan.yml
+++ b/.github/workflows/crd-epic-plan.yml
@@ -97,7 +97,7 @@ jobs:
           echo "PLAN_OK"
 
       - name: Publicar artefatos (plan)
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: crd-epic-plan-${{ github.ref_name }}-${{ github.run_id }}
           path: ${{ steps.io.outputs.out_dir }}/

--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload guard artifacts
         if: ${{ !matrix.clean_runner }}
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: boss-stage-${{ matrix.stage }}
           path: out/q1_boss_final/stages/${{ matrix.stage }}
@@ -139,37 +139,37 @@ jobs:
             jsonschema==4.23.0
 
       - name: Download stage artifacts
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@65d8626b53fa662845d786fc8c2cd0a76f1b38f1
         with:
           name: boss-stage-s1
           path: out/q1_boss_final/stages/s1
 
       - name: Download stage artifacts s2
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@65d8626b53fa662845d786fc8c2cd0a76f1b38f1
         with:
           name: boss-stage-s2
           path: out/q1_boss_final/stages/s2
 
       - name: Download stage artifacts s3
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@65d8626b53fa662845d786fc8c2cd0a76f1b38f1
         with:
           name: boss-stage-s3
           path: out/q1_boss_final/stages/s3
 
       - name: Download stage artifacts s4
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@65d8626b53fa662845d786fc8c2cd0a76f1b38f1
         with:
           name: boss-stage-s4
           path: out/q1_boss_final/stages/s4
 
       - name: Download stage artifacts s5
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@65d8626b53fa662845d786fc8c2cd0a76f1b38f1
         with:
           name: boss-stage-s5
           path: out/q1_boss_final/stages/s5
 
       - name: Download stage artifacts s6
-        uses: actions/download-artifact@8b0f5668a7fe5adb56c1fb26a40cc1a2ddcae4c6
+        uses: actions/download-artifact@65d8626b53fa662845d786fc8c2cd0a76f1b38f1
         with:
           name: boss-stage-s6
           path: out/q1_boss_final/stages/s6
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: q1-boss-final
           path: ${{ env.REPORT_DIR }}

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Upload guard report
         if: always()
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: repo-guard-report
           path: out/repo_guard/**/*.txt

--- a/.github/workflows/s5-validation.yml
+++ b/.github/workflows/s5-validation.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Sprint 5 artifacts
         if: always()
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: sprint5-validation-artifacts
           path: |

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -206,7 +206,7 @@ jobs:
         run: python scripts/scorecards/s6_scorecards.py
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@a8a3bc47d66b9b4ade100e3f1920993de94506ee
+        uses: actions/upload-artifact@5076951413fa71e81ff98d6b871c3e9df2bda29b
         with:
           name: s6-scorecards
           path: ${{ env.REPORT_DIR }}

--- a/actions.lock
+++ b/actions.lock
@@ -1,6 +1,9 @@
 actions:
   actions/checkout: 11bd71901bbe5b1630ceea73d27597364c9af683
+  actions/download-artifact: 65d8626b53fa662845d786fc8c2cd0a76f1b38f1
+  actions/upload-artifact: 5076951413fa71e81ff98d6b871c3e9df2bda29b
+  docker/login-action: f4ef339be1f7c0066db2ed1d1c637d705d7d76e8
 metadata:
-  updated_at: 2025-10-26T20:58:45Z
+  updated_at: 2025-10-26T21:21:14Z
   updated_by: codex
-  rationale: "Fix do pin de actions/checkout após erro 404 (SHA inválido)."
+  rationale: "Sweep de pins: normalização para SHAs válidos (compat Node 20)."


### PR DESCRIPTION
## Summary
- repin all workflows to valid commit SHAs for actions/upload-artifact, actions/download-artifact, and docker/login-action
- update actions.lock with the resolved SHAs and refreshed metadata for the compat (Node 20) baseline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe8f955c4c83308a264965ca6babe5