### PR TITLE
Add sanity guard for GitHub action pins

### DIFF
--- a/.github/workflows/sanity-actions.yml
+++ b/.github/workflows/sanity-actions.yml
@@ -1,0 +1,67 @@
+name: Sanity — Actions Pins
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+  schedule:
+    - cron: '17 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Resolve & Verify Pins
+        shell: bash
+        run: |
+          set -euo pipefail
+          list(){ find .github -type f \( -name "*.yml" -o -name "*.yaml" \) | sort -u; }
+          : > .pins
+          python - <<'PY'
+import re,sys,os
+pat_inline=re.compile(r"^\s*uses:\s*([\"\']?)([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^\"'\s#]+)\1\s*$")
+pat_key=re.compile(r"^\s*uses:\s*$")
+pat_val=re.compile(r"^\s*([\"\']?)([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^\"'\s#]+)\1\s*$")
+files=[]
+for d,_,fs in os.walk('.github'):
+  for f in fs:
+    if f.endswith(('.yml','.yaml')): files.append(os.path.join(d,f))
+files.sort()
+for f in files:
+  with open(f,'r',encoding='utf-8',errors='ignore') as h: L=h.readlines()
+  i=0
+  while i<len(L):
+    ln=L[i]
+    m=pat_inline.match(ln)
+    if m:
+      q,a,r=m.groups();
+      if not (a.startswith('./') or a.startswith('docker://')):
+        print(f"{f}\t{a}\t{r}")
+      i+=1; continue
+    if pat_key.match(ln) and i+1<len(L):
+      v=L[i+1]; m2=pat_val.match(v)
+      if m2:
+        q,a,r=m2.groups()
+        if not (a.startswith('./') or a.startswith('docker://')):
+          print(f"{f}\t{a}\t{r}")
+        i+=2; continue
+    i+=1
+PY > .pins
+          FAIL=0
+          while IFS=$'\t' read -r file action ref; do
+            if ! echo "$ref" | grep -Eq '^[0-9a-fA-F]{40}$'; then echo "NO-SHA: $file $action@$ref" >> .summary; FAIL=1; continue; fi
+            code=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/${action}/commits/${ref}")
+            if [ "$code" != "200" ]; then echo "NO-COMMIT: $file $action@$ref ($code)" >> .summary; FAIL=1; fi
+          done < .pins
+          echo "Sanity Pins — $(date -u +%F)" > $GITHUB_STEP_SUMMARY
+          if [ -s .summary ]; then
+            echo "\n**Issues:**" >> $GITHUB_STEP_SUMMARY
+            sed -E 's/^/- /' .summary >> $GITHUB_STEP_SUMMARY
+          else
+            echo "\nTudo OK: todos os uses possuem SHA(40) válido." >> $GITHUB_STEP_SUMMARY
+          fi
+          exit $FAIL

--- a/actions.lock
+++ b/actions.lock
@@ -4,6 +4,6 @@ actions:
   actions/upload-artifact: 5076951413fa71e81ff98d6b871c3e9df2bda29b
   docker/login-action: f4ef339be1f7c0066db2ed1d1c637d705d7d76e8
 metadata:
-  updated_at: 2025-10-26T21:21:14Z
+  updated_at: 2025-10-26T21:52:47Z
   updated_by: codex
-  rationale: "Sweep de pins: normalização para SHAs válidos (compat Node 20)."
+  rationale: Sweep pins → SHA(40), higiene YAML/JSON (compat Node 20).


### PR DESCRIPTION
## Summary
- refresh the actions.lock metadata after running the v5 pin sweep
- add a sanity guard workflow that verifies every GitHub Action pin resolves to an existing commit and reports failures via the PR summary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe97751dc88330842ca4ef1994d794