### PR TITLE
Refactor Semgrep execution into reusable workflow

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -67,8 +67,17 @@ permissions:
   contents: read
   actions: write
   id-token: write
+  security-events: write
 
 jobs:
+  semgrep_scan:
+    if: ${{ inputs.run_security }}
+    uses: ./.github/workflows/semgrep.yml
+    with:
+      ref: ${{ inputs.ref || github.sha }}
+      fail_on_findings: ${{ inputs.security_fail_on_findings }}
+    secrets: inherit
+
   orr:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
@@ -77,19 +86,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ inputs.ref || github.sha }}
-
-      - name: Security | Install Semgrep (pip<2)
-        if: ${{ inputs.run_security }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p out/security
-          if command -v semgrep >/dev/null 2>&1; then
-            semgrep --version | tee out/security/semgrep-version.txt
-            exit 0
-          fi
-          python3 -m pip install --upgrade "semgrep<2"
-          semgrep --version | tee out/security/semgrep-version.txt
 
       - name: Security | Install Gitleaks (tarball)
         if: ${{ inputs.run_security }}
@@ -138,23 +134,6 @@ jobs:
             exit 0
           fi
           trivy --version | head -n1 | tee out/security/trivy-version.txt
-
-      - name: Security | Semgrep scan
-        if: ${{ inputs.run_security }}
-        shell: bash
-        continue-on-error: ${{ !inputs.security_fail_on_findings }}
-        run: |
-          set -euo pipefail
-          mkdir -p out/security
-          JSON="out/security/semgrep-report.json"
-          LOG="out/security/semgrep-report.txt"
-          : > "$LOG"
-          set +e
-          semgrep --config auto --json --output "$JSON" 2>&1 | tee "$LOG"
-          STATUS=${PIPESTATUS[0]}
-          set -e
-          printf '%s\n' "$STATUS" > out/security/semgrep-exit-code.txt
-          exit "$STATUS"
 
       - name: Security | Gitleaks detect
         if: ${{ inputs.run_security }}
@@ -209,7 +188,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "[setup] k6: $( (command -v k6 >/dev/null && k6 version) || echo 'não instalado ou usando Docker via K6_BIN')"
-          echo "[setup] semgrep: $( (command -v semgrep >/dev/null && semgrep --version) || echo 'não instalado')"
+          echo "[setup] semgrep: executado via workflow dedicado"
           echo "[setup] trivy: $( (command -v trivy >/dev/null && trivy --version | head -n1) || echo 'não instalado')"
           echo "[setup] gitleaks: $( (command -v gitleaks >/dev/null && gitleaks version | head -n1) || echo 'não instalado')"
 
@@ -445,9 +424,6 @@ jobs:
           fi
           if ! command -v trivy >/dev/null 2>&1; then
             sudo apt-get install -y trivy
-          fi
-          if ! command -v semgrep >/dev/null 2>&1; then
-            python3 -m pip install --upgrade 'semgrep<2'
           fi
           if ! command -v gitleaks >/dev/null 2>&1; then
             VER="8.18.1"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,81 @@
+name: semgrep
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: Optional ref to scan
+        required: false
+        type: string
+      fail_on_findings:
+        description: Fail the workflow when findings are detected
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      SEMGREP_APP_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Semgrep Scan
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Run Semgrep
+        id: semgrep
+        uses: returntocorp/semgrep-action@v1
+        continue-on-error: ${{ !inputs.fail_on_findings }}
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        with:
+          config: auto
+          generateSarif: true
+          publishSarif: true
+
+      - name: Collect Semgrep artifacts
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p out/security
+          if [ -f semgrep.sarif ]; then
+            cp semgrep.sarif out/security/semgrep.sarif
+          fi
+          if [ -f semgrep.json ]; then
+            cp semgrep.json out/security/semgrep.json
+          fi
+          if [ -f semgrep.log ]; then
+            cp semgrep.log out/security/semgrep.log
+          fi
+
+      - name: Upload Semgrep artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: semgrep-artifacts
+          path: out/security/**
+          if-no-files-found: warn
+
+      - name: Record Semgrep outcome
+        if: ${{ always() }}
+        id: summary
+        shell: bash
+        run: |
+          if [ "${{ steps.semgrep.outcome }}" = "failure" ]; then
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+          fi
+
+    outputs:
+      exit_code: ${{ steps.summary.outputs.exit_code }}

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,7 +1,6 @@
 dbt-core==1.6.4
 dbt-bigquery==1.6.4
 jsonschema==4.23.0
-semgrep==1.80.0
 requests==2.31.0
 hypothesis==6.103.0
 pytest==8.3.3


### PR DESCRIPTION
## Summary
- remove the Semgrep pin from requirements.lock
- add a reusable Semgrep workflow using the official action and SARIF artifacts
- update the _s4-orr workflow to delegate Semgrep checks and drop pip installs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fead69e80083308cc7cef7de3413fc