### PR TITLE
Boss Final v10 guard silencioso e permissões do aggregator

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -102,8 +102,6 @@ jobs:
       - name: Execute sprint guard
         timeout-minutes: 5
         run: bash scripts/boss_final/ci_stage_wrapper.sh
-        continue-on-error: true
-
       - name: Upload stage artifact (always)
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -115,6 +113,9 @@ jobs:
   aggregate:
     name: Aggregate Boss Final
     needs: stage
+    permissions:
+      actions: read
+      contents: read
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -166,7 +167,7 @@ jobs:
         id: aggregate
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           REPORT_DIR: ${{ env.REPORT_DIR }}
         run: |
           set -euo pipefail

--- a/scripts/boss_final/ci_stage_wrapper.sh
+++ b/scripts/boss_final/ci_stage_wrapper.sh
@@ -5,18 +5,16 @@ CLEAN_RUNNER="${CLEAN_RUNNER:-false}"
 ARTDIR="${ARTIFACT_DIR:-$RUNNER_TEMP/boss-stage-${STAGE}}"
 mkdir -p "$ARTDIR"
 LOG="$ARTDIR/guard.log"
-# Executa guard e captura exit code sem abortar o upload
 set +e
 . ./.venv/bin/activate 2>/dev/null || true
 python scripts/boss_final/sprint_guard.py --stage "$STAGE" | tee "$LOG"
 CODE=${PIPESTATUS[0]}
 set -e
-# report.json mínimo por stage
 python - "$STAGE" "$CLEAN_RUNNER" "$CODE" "$ARTDIR/report.json" <<'PY'
 import json,sys
 stage,clean,code,out=sys.argv[1],sys.argv[2],int(sys.argv[3]),sys.argv[4]
 rep={"stages":[{"name":stage,"clean":(clean=="true"),"status":"passed" if code==0 else "failed","exit_code":code}]}
 open(out,'w',encoding='utf-8').write(json.dumps(rep,ensure_ascii=False))
 PY
-# propaga o exit code original
-exit "$CODE"
+if [ "$CODE" -ne 0 ]; then echo "::notice title=Guard::$STAGE falhou (exit=$CODE), ver artifact boss-stage-$STAGE::detalhes no guard.log e report.json"; fi
+exit 0


### PR DESCRIPTION
## Summary
- wrap the sprint guard execution in a new ci_stage_wrapper that records report.json, emits a notice, and always exits 0 so the job stays green
- update the Q1 Boss Final workflow to use the wrapper, always upload artifacts, and grant the aggregator job actions:read with github.token for artifact downloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68febebcf24c833084addc13720d2ae0