### PR TITLE
Boss Final v13: fix guard logging and normalize aggregate paths

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -115,8 +115,8 @@ jobs:
     timeout-minutes: 30
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
-      REPORT_DIR: ${{ github.workspace }}/.boss-aggregate
-      ARTS_DIR: ${{ github.workspace }}/.boss-arts
+      ARTS_DIR: ${{ runner.temp }}/boss-arts
+      REPORT_DIR: ${{ runner.temp }}/boss-aggregate
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -159,21 +159,20 @@ jobs:
       - name: Aggregate reports (local)
         if: always()
         id: aggregate
-        env:
-          ARTS_DIR: ${{ env.ARTS_DIR }}
-          REPORT_DIR: ${{ env.REPORT_DIR }}
         run: |
           set -euo pipefail
           mkdir -p "$REPORT_DIR"
           . .venv/bin/activate 2>/dev/null || true
           python scripts/boss_final/aggregate_reports_local.py | tee "$REPORT_DIR/aggregate.log"
 
-      - name: Upload artifacts
+      - name: Upload Boss Final aggregate
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: q1-boss-final
+          name: boss-final-aggregate
           path: ${{ env.REPORT_DIR }}
+          retention-days: 7
+          overwrite: true
 
       - name: Validate report schema (local)
         if: always()

--- a/scripts/boss_final/aggregate_reports_local.py
+++ b/scripts/boss_final/aggregate_reports_local.py
@@ -1,34 +1,41 @@
 import json
 import os
+from pathlib import Path
 
-root = os.environ.get('ARTS_DIR') or os.path.join(os.environ.get('RUNNER_TEMP', '.'), 'boss-arts')
+arts_dir = os.environ.get('ARTS_DIR') or os.path.join(os.environ.get('RUNNER_TEMP', '.'), 'boss-arts')
 report_dir = os.environ.get('REPORT_DIR') or os.path.join(os.environ.get('RUNNER_TEMP', '.'), 'boss-aggregate')
 os.makedirs(report_dir, exist_ok=True)
 found: list[dict] = []
-for d, _, fs in os.walk(root):
-    for f in fs:
-        if f == 'report.json':
+for dirpath, _, filenames in os.walk(arts_dir):
+    for filename in filenames:
+        if filename == 'report.json':
             try:
-                with open(os.path.join(d, f), encoding='utf-8') as handle:
+                with open(os.path.join(dirpath, filename), encoding='utf-8') as handle:
                     payload = json.load(handle)
                 if isinstance(payload, dict) and isinstance(payload.get('stages'), list):
                     found.extend(payload['stages'])
-            except Exception as exc:  # pragma: no cover - defensive
+            except Exception as exc:  # pragma: no cover - defensivo
                 found.append({'name': 'unknown', 'status': 'error', 'errors': [str(exc)]})
-names = {s.get('name') for s in found}
+names = {stage.get('name') for stage in found}
 for idx in range(1, 7):
     stage_name = f's{idx}'
     if stage_name not in names:
         found.append({'name': stage_name, 'status': 'missing', 'errors': ['artifact not found']})
-report_path = os.path.join(report_dir, 'report.json')
-with open(report_path, 'w', encoding='utf-8') as handle:
+report_path = Path(report_dir) / 'report.json'
+with report_path.open('w', encoding='utf-8') as handle:
     json.dump({'stages': found}, handle, ensure_ascii=False)
-status = 'PASS' if all(s.get('status') == 'passed' for s in found) else 'FAIL'
-with open(os.path.join(report_dir, 'guard_status.txt'), 'w', encoding='utf-8') as handle:
-    handle.write(status + '\n')
-lines = [f"| {s.get('name', '?')} | {s.get('status', 'unknown')} |" for s in found]
-header = ['| Stage | Status |', '| --- | --- |']
-comment_path = os.path.join(report_dir, 'pr_comment.md')
-with open(comment_path, 'w', encoding='utf-8') as handle:
-    handle.write('Q1 Boss Final — Stage Summary\n\n')
-    handle.write('\n'.join(header + lines) + '\n')
+counts = {
+    status: sum(1 for stage in found if stage.get('status') == status)
+    for status in {'passed', 'failed', 'missing', 'error'}
+}
+summary = {'summary': {'counts': counts}}
+print(json.dumps(summary, ensure_ascii=False))
+status_value = 'PASS' if all(stage.get('status') == 'passed' for stage in found) else 'FAIL'
+(Path(report_dir) / 'guard_status.txt').write_text(status_value + '\n', encoding='utf-8')
+lines = ['| Stage | Status |', '| --- | --- |']
+for stage in sorted(found, key=lambda item: item.get('name', '')):
+    lines.append(f"| {stage.get('name', '?')} | {stage.get('status', 'unknown')} |")
+(Path(report_dir) / 'pr_comment.md').write_text(
+    'Q1 Boss Final — Stage Summary\n\n' + '\n'.join(lines) + '\n',
+    encoding='utf-8',
+)

--- a/scripts/boss_final/ci_stage_wrapper.sh
+++ b/scripts/boss_final/ci_stage_wrapper.sh
@@ -7,7 +7,7 @@ mkdir -p "$ARTDIR"
 LOG="$ARTDIR/guard.log"
 . ./.venv/bin/activate 2>/dev/null || true
 set +e
-python scripts/boss_final/sprint_guard.py --stage "$STAGE" | tee "$LOG"
+python scripts/boss_final/sprint_guard.py --stage "$STAGE" 2>&1 | tee "$LOG"
 CODE=${PIPESTATUS[0]}
 set -e
 python - "$STAGE" "$CLEAN_RUNNER" "$CODE" "$ARTDIR/report.json" <<'PY'


### PR DESCRIPTION
## Summary
- capture sprint guard stderr in guard.log without altering exit behavior
- update the local report aggregator to rely on ARTS_DIR/REPORT_DIR and emit summary artifacts
- point the Boss Final workflow to runner.temp paths and upload the normalized aggregate artifact

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68fed45e46b483309afccf033f803825