### PR TITLE
Boss Final v15: ensure guard log visibility and aggregate artifacts

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -1,3 +1,6 @@
+permissions:
+  actions: read
+  contents: read
 name: Q1 Boss Final
 
 on:
@@ -96,12 +99,18 @@ jobs:
       - name: Execute sprint guard
         timeout-minutes: 5
         run: bash scripts/boss_final/ci_stage_wrapper.sh
+      - name: List stage artifact dir (debug)
+        if: always()
+        run: |
+          set -euo pipefail
+          ls -la "${{ runner.temp }}" || true
+          ls -la "${{ runner.temp }}/boss-stage-${{ env.STAGE }}" || true
       - name: Upload stage artifact (always)
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: boss-stage-${{ env.STAGE }}
-          path: ${{ env.STAGE_ARTIFACT_DIR }}
+          path: ${{ runner.temp }}/boss-stage-${{ env.STAGE }}
           retention-days: 7
           overwrite: true
   aggregate:
@@ -166,15 +175,6 @@ jobs:
           . .venv/bin/activate 2>/dev/null || true
           python scripts/boss_final/aggregate_reports_local.py | tee "$REPORT_DIR/aggregate.log"
 
-      - name: Upload Boss Final aggregate
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: boss-final-aggregate
-          path: ${{ runner.temp }}/boss-aggregate
-          retention-days: 7
-          overwrite: true
-
       - name: Validate report schema (local)
         if: always()
         env:
@@ -183,6 +183,15 @@ jobs:
           set -euo pipefail
           . .venv/bin/activate 2>/dev/null || true
           python -m jsonschema --instance "$REPORT_DIR/report.json" --schema schemas/q1_boss_report.schema.json
+
+      - name: Upload Boss Final aggregate
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: boss-final-aggregate
+          path: ${{ runner.temp }}/boss-aggregate
+          retention-days: 7
+          overwrite: true
 
       - name: Evaluate guard status
         if: always()

--- a/scripts/boss_final/ci_stage_wrapper.sh
+++ b/scripts/boss_final/ci_stage_wrapper.sh
@@ -16,4 +16,11 @@ stage,clean,code,out=sys.argv[1],sys.argv[2],int(sys.argv[3]),sys.argv[4]
 rep={"stages":[{"name":stage,"clean":(clean=="true"),"status":"passed" if code==0 else "failed","exit_code":code}]}
 open(out,'w',encoding='utf-8').write(json.dumps(rep,ensure_ascii=False))
 PY
+# Publica resumo no Step Summary (últimas 300 linhas do log)
+{
+  echo "### Guard — ${STAGE} (exit=${CODE})";
+  echo; echo '\`\`\`';
+  tail -n 300 "$LOG" || true; echo '\`\`\`'
+} >> "$GITHUB_STEP_SUMMARY" || true
+# Propaga o exit code real (sem silenciar)
 exit "$CODE"


### PR DESCRIPTION
## Summary
- add a reusable CI wrapper that runs the sprint guard, records the exit code, and mirrors the log in the job summary
- update the Q1 Boss Final workflow to always publish stage artifacts with debug listings and standardized runner.temp paths
- run the aggregate job unconditionally while downloading artifacts by pattern, validating the combined report, and uploading it from the correct directory

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68feda7a11208330bd7c8e9d9deb9802