### PR TITLE
Sweep v18: normalize setup-python pin to valid SHA

### DIFF
--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -3,7 +3,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python 3.11
-      uses: actions/setup-python@afa3a9d50f1d3a1b9aba0e2fe61f15b0f1b7f735 # v5.2.0
+      uses: actions/setup-python@57ded73d95736b4867d21e0da0f2e054fea0f6e7 # v5.3.0
       with:
         python-version: '3.11'
         check-latest: true

--- a/.github/scripts/resolve_pins.py
+++ b/.github/scripts/resolve_pins.py
@@ -3,6 +3,7 @@ FALLBACKS={
   "actions/checkout":"v4.2.2",
   "actions/upload-artifact":"v4",
   "actions/download-artifact":"v4",
+  "actions/setup-python":"v5.3.0",
   "actions/cache":"v4",
   "actions/github-script":"v7"
 }

--- a/actions.lock
+++ b/actions.lock
@@ -1,10 +1,11 @@
 actions:
   actions/checkout: 11bd71901bbe5b1630ceea73d27597364c9af683
   actions/download-artifact: d3f86a106a0bac45b974a628896c90dbdf5c8093
+  actions/setup-python: 57ded73d95736b4867d21e0da0f2e054fea0f6e7
   actions/upload-artifact: ea165f8d65b6e75b540449e92b4886f43607fa02
   docker/login-action: f4ef339be1f7c0066db2ed1d1c637d705d7d76e8
   returntocorp/semgrep-action: d2118d8864c8ad5ac2ffb5f062e30aea0a43d0f0
 metadata:
-  updated_at: 2025-10-27T01:26:27+00:00
+  updated_at: 2025-10-27T03:46:38Z
   updated_by: codex
-  rationale: Sweep pins via resolve_pins.py
+  rationale: Sweep v18 — normalização para SHAs válidos (inclui setup-python)


### PR DESCRIPTION
## Summary
- update the composite setup-python helper to use a valid SHA for actions/setup-python@v5.3.0
- extend the resolve_pins helper to fall back to actions/setup-python v5.3.0
- refresh actions.lock with the setup-python mapping and updated metadata

## Testing
- python .github/scripts/verify_pins.py

------
https://chatgpt.com/codex/tasks/task_e_68fee9455b00833095f5405e40eb5c3c