### PR TITLE
Fix boss final workflow inline python

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -284,28 +284,7 @@ jobs:
           cp "$REPORT_DIR/report.json" "out/boss_final/report.local.json"
           . .venv/bin/activate 2>/dev/null || true
           python scripts/boss_final/ensure_schema.py out/boss_final/report.local.json
-          python - <<'PY'
-import hashlib
-import json
-import os
-import pathlib
-
-path = pathlib.Path("out/boss_final/report.local.json")
-digest = hashlib.sha256(path.read_bytes()).hexdigest()
-(path.parent / "report.local.json.sha256.txt").write_text(digest + "\n", encoding="utf-8")
-data = json.loads(path.read_text(encoding="utf-8"))
-lines = [
-    f"report_path: {path.resolve()}",
-    f"schema: {data.get('schema', '<missing>')}",
-    f"generated_at: {data.get('generated_at', '<missing>')}",
-]
-(path.parent / "diagnostics.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
-print("\n".join(lines))
-with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
-    handle.write(f"schema={data.get('schema', '')}\n")
-    handle.write(f"generated_at={data.get('generated_at', '')}\n")
-    handle.write(f"sha256={digest}\n")
-PY
+          python scripts/boss_final/generate_local_evidence.py out/boss_final/report.local.json
 
       - name: Append local aggregate summary
         if: steps.aggregate.outcome == 'success'

--- a/scripts/boss_final/generate_local_evidence.py
+++ b/scripts/boss_final/generate_local_evidence.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate local evidence metadata for Boss Final reports."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+from typing import Optional
+
+
+def _format_lines(path: pathlib.Path, schema: Optional[str], generated_at: Optional[str]) -> list[str]:
+    return [
+        f"report_path: {path.resolve()}",
+        f"schema: {schema or '<missing>'}",
+        f"generated_at: {generated_at or '<missing>'}",
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report_path", type=pathlib.Path, help="Path to the report JSON file")
+    parser.add_argument(
+        "--diagnostics-path",
+        type=pathlib.Path,
+        default=None,
+        help="Optional path for the diagnostics output file",
+    )
+    args = parser.parse_args()
+
+    report_path = args.report_path
+    if not report_path.is_file():
+        raise SystemExit(f"Report file not found: {report_path}")
+
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    digest = hashlib.sha256(report_path.read_bytes()).hexdigest()
+
+    diagnostics_path = args.diagnostics_path or report_path.parent / "diagnostics.txt"
+    lines = _format_lines(
+        report_path,
+        schema=data.get("schema"),
+        generated_at=data.get("generated_at"),
+    )
+    diagnostics_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    digest_path = report_path.parent / "report.local.json.sha256.txt"
+    digest_path.write_text(digest + "\n", encoding="utf-8")
+
+    print("\n".join(lines))
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"schema={data.get('schema', '')}\n")
+            handle.write(f"generated_at={data.get('generated_at', '')}\n")
+            handle.write(f"sha256={digest}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extract the evidence bundle metadata generation into `scripts/boss_final/generate_local_evidence.py`
- update the Boss Final workflow to call the new helper instead of embedding inline Python

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ffe2670c1c8330b7f1da876846da19