### PR TITLE
fix: align boss final utilities with Ruff and schema defaults

### DIFF
--- a/.github/scripts/verify_actions_lock.py
+++ b/.github/scripts/verify_actions_lock.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import json
 import argparse
 import json
 import re

--- a/scripts/boss_final/ensure_schema.py
+++ b/scripts/boss_final/ensure_schema.py
@@ -1,45 +1,58 @@
 #!/usr/bin/env python3
-"""Ensure the local Boss Final aggregate report declares its schema."""
-
 from __future__ import annotations
 
-import datetime
+import argparse
 import json
 import pathlib
-import sys
+from datetime import datetime, timezone
 
 
-def _default_path() -> pathlib.Path:
-    return pathlib.Path("out/boss_final/report.local.json")
-
-
-def _find_candidate() -> pathlib.Path:
-    candidates = sorted(pathlib.Path("out").rglob("report.local.json"))
+def _find_candidate(root: pathlib.Path = pathlib.Path("out")) -> pathlib.Path:
+    candidates = sorted(root.rglob("report.local.json"))
     if not candidates:
-        raise SystemExit("[ensure-schema] relatório não encontrado: out/boss_final/report.local.json")
+        raise SystemExit(
+            "[ensure-schema] relatório não encontrado: out/boss_final/report.local.json"
+        )
     return candidates[0]
 
 
 def main() -> None:
-    target_arg = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else _default_path()
-    path = target_arg if target_arg.exists() else _find_candidate()
+    parser = argparse.ArgumentParser(
+        description="Ensure Boss Final local aggregate report declares schema metadata."
+    )
+    parser.add_argument(
+        "report",
+        nargs="?",
+        type=pathlib.Path,
+        default=None,
+        help="Optional explicit report.local.json path.",
+    )
+    args = parser.parse_args()
 
+    path = args.report if args.report and args.report.exists() else _find_candidate()
     data = json.loads(path.read_text(encoding="utf-8"))
     changed = False
-    if "schema" not in data:
-        data["schema"] = "boss_final.report@v1"
+
+    if (
+        "schema" not in data
+        or not isinstance(data["schema"], str)
+        or not data["schema"]
+    ):
+        data["schema"] = "boss_final.report@1"
         changed = True
+
     if "generated_at" not in data:
-        data["generated_at"] = (
-            datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-        )
+        data["generated_at"] = datetime.now(timezone.utc).isoformat()
         changed = True
 
     if changed:
-        path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
 
     print(f"[ensure-schema] OK: {path} | schema: {data['schema']}")
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     main()

--- a/scripts/boss_final/generate_local_evidence.py
+++ b/scripts/boss_final/generate_local_evidence.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Generate local evidence metadata for Boss Final reports."""
+
 from __future__ import annotations
 
 import argparse
@@ -10,7 +11,11 @@ import pathlib
 from typing import Optional
 
 
-def _format_lines(path: pathlib.Path, schema: Optional[str], generated_at: Optional[str]) -> list[str]:
+def _format_lines(
+    path: pathlib.Path,
+    schema: Optional[str],
+    generated_at: Optional[str],
+) -> list[str]:
     return [
         f"report_path: {path.resolve()}",
         f"schema: {schema or '<missing>'}",
@@ -20,7 +25,11 @@ def _format_lines(path: pathlib.Path, schema: Optional[str], generated_at: Optio
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("report_path", type=pathlib.Path, help="Path to the report JSON file")
+    parser.add_argument(
+        "report_path",
+        type=pathlib.Path,
+        help="Path to the report JSON file",
+    )
     parser.add_argument(
         "--diagnostics-path",
         type=pathlib.Path,


### PR DESCRIPTION
## Summary
- remove the duplicate `json` import from `.github/scripts/verify_actions_lock.py` to clear the Ruff F811 error
- refresh `scripts/boss_final/ensure_schema.py` to use argparse, guard schema metadata, and only rewrite the file when updates are needed
- tidy `scripts/boss_final/generate_local_evidence.py` and the aggregate schema test with Ruff-friendly formatting and shared fixtures

## Testing
- ruff check --fix .
- ruff format .
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68ffef70cf70833080407793e09020ca