### PR TITLE
fix(boss-final): add schema_version + ruff cleanup; make aggregate local/global consistent

### DIFF
--- a/out/boss/boss-final-report.json
+++ b/out/boss/boss-final-report.json
@@ -1,4 +1,6 @@
 {
+  "schema": "boss_final.report@1",
+  "schema_version": 1,
   "stages": [
     {
       "name": "s1",

--- a/scripts/boss_final/aggregate_reports.py
+++ b/scripts/boss_final/aggregate_reports.py
@@ -13,6 +13,8 @@ from typing import Dict, List
 from urllib import request
 from urllib.error import HTTPError, URLError
 
+from ensure_schema import ensure_schema_metadata
+
 STAGE_COUNT = 6
 ARTIFACT_PREFIX = "boss-stage-"
 
@@ -218,6 +220,7 @@ def main() -> int:
         "stages": stages,
         "summary": {"counts": summary_counts},
     }
+    ensure_schema_metadata(report)
     report_path = os.path.join(out_dir, "report.json")
     with open(report_path, "w", encoding="utf-8") as handle:
         json.dump(report, handle, ensure_ascii=False, indent=2)

--- a/scripts/boss_final/aggregate_reports_local.py
+++ b/scripts/boss_final/aggregate_reports_local.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
+from ensure_schema import ensure_schema_metadata
+
 RUNNER_TEMP = Path(os.environ.get("RUNNER_TEMP", "."))
 ARTS_DIR = Path(os.environ.get("ARTS_DIR") or RUNNER_TEMP / "boss-arts")
 OUT_DIR = Path(os.environ.get("REPORT_DIR") or RUNNER_TEMP / "boss-aggregate")
@@ -46,7 +48,7 @@ def ensure_missing_stages(results: List[Dict[str, Any]]) -> None:
 def write_aggregate(results: List[Dict[str, Any]], out_dir: Path) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     aggregate: Dict[str, Any] = {"stages": results}
-    aggregate.setdefault("schema", "boss_final.report@v1")
+    ensure_schema_metadata(aggregate)
     aggregate.setdefault(
         "generated_at",
         datetime.now(timezone.utc).isoformat(timespec="seconds"),

--- a/scripts/boss_final/ensure_schema.py
+++ b/scripts/boss_final/ensure_schema.py
@@ -4,7 +4,55 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import re
 from datetime import datetime, timezone
+from typing import Any, Dict
+
+SCHEMA_PREFIX = "boss_final.report"
+DEFAULT_VERSION = 1
+SCHEMA_PATTERN = re.compile(rf"^{re.escape(SCHEMA_PREFIX)}@(\d+)$")
+
+
+def _default_schema() -> str:
+    return f"{SCHEMA_PREFIX}@{DEFAULT_VERSION}"
+
+
+def _extract_version(schema: object) -> int | None:
+    if not isinstance(schema, str):
+        return None
+    candidate = schema.strip()
+    if not candidate:
+        return None
+    match = SCHEMA_PATTERN.fullmatch(candidate)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def ensure_schema_metadata(payload: Dict[str, Any]) -> bool:
+    """Ensure schema fields are present and consistent."""
+
+    changed = False
+    version = _extract_version(payload.get("schema"))
+
+    if version is None:
+        payload["schema"] = _default_schema()
+        version = DEFAULT_VERSION
+        changed = True
+    else:
+        normalized_schema = f"{SCHEMA_PREFIX}@{version}"
+        if payload.get("schema") != normalized_schema:
+            payload["schema"] = normalized_schema
+            changed = True
+
+    if payload.get("schema_version") != version:
+        payload["schema_version"] = version
+        changed = True
+
+    return changed
 
 
 def _find_candidate(root: pathlib.Path = pathlib.Path("out")) -> pathlib.Path:
@@ -31,15 +79,7 @@ def main() -> None:
 
     path = args.report if args.report and args.report.exists() else _find_candidate()
     data = json.loads(path.read_text(encoding="utf-8"))
-    changed = False
-
-    if (
-        "schema" not in data
-        or not isinstance(data["schema"], str)
-        or not data["schema"]
-    ):
-        data["schema"] = "boss_final.report@1"
-        changed = True
+    changed = ensure_schema_metadata(data)
 
     if "generated_at" not in data:
         data["generated_at"] = datetime.now(timezone.utc).isoformat()
@@ -51,7 +91,10 @@ def main() -> None:
             encoding="utf-8",
         )
 
-    print(f"[ensure-schema] OK: {path} | schema: {data['schema']}")
+    print(
+        "[ensure-schema] OK: %s | schema: %s | schema_version: %s"
+        % (path, data["schema"], data.get("schema_version"))
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/boss_final/generate_local_evidence.py
+++ b/scripts/boss_final/generate_local_evidence.py
@@ -14,11 +14,13 @@ from typing import Optional
 def _format_lines(
     path: pathlib.Path,
     schema: Optional[str],
+    schema_version: Optional[int],
     generated_at: Optional[str],
 ) -> list[str]:
     return [
         f"report_path: {path.resolve()}",
         f"schema: {schema or '<missing>'}",
+        f"schema_version: {schema_version if schema_version is not None else '<missing>'}",
         f"generated_at: {generated_at or '<missing>'}",
     ]
 
@@ -46,9 +48,17 @@ def main() -> None:
     digest = hashlib.sha256(report_path.read_bytes()).hexdigest()
 
     diagnostics_path = args.diagnostics_path or report_path.parent / "diagnostics.txt"
+    schema_version_raw = data.get("schema_version")
+    schema_version = None
+    if isinstance(schema_version_raw, int):
+        schema_version = schema_version_raw
+    elif isinstance(schema_version_raw, str) and schema_version_raw.isdigit():
+        schema_version = int(schema_version_raw)
+
     lines = _format_lines(
         report_path,
         schema=data.get("schema"),
+        schema_version=schema_version,
         generated_at=data.get("generated_at"),
     )
     diagnostics_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -62,6 +72,9 @@ def main() -> None:
     if github_output:
         with open(github_output, "a", encoding="utf-8") as handle:
             handle.write(f"schema={data.get('schema', '')}\n")
+            handle.write(
+                f"schema_version={schema_version if schema_version is not None else ''}\n"
+            )
             handle.write(f"generated_at={data.get('generated_at', '')}\n")
             handle.write(f"sha256={digest}\n")
 

--- a/tests/boss_final/test_aggregate_local_schema.py
+++ b/tests/boss_final/test_aggregate_local_schema.py
@@ -57,4 +57,7 @@ def test_local_aggregate_contains_schema(
     assert data["schema"].startswith("boss_final.report@"), (
         "Campo `schema` ausente ou inválido"
     )
+    assert isinstance(data.get("schema_version"), int) and data["schema_version"] > 0, (
+        "Campo `schema_version` ausente ou inválido"
+    )
     assert "generated_at" in data, "`generated_at` ausente"

--- a/tests/boss_final/test_aggregate_q1.py
+++ b/tests/boss_final/test_aggregate_q1.py
@@ -159,6 +159,8 @@ def test_aggregate_pass(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     report = aggregate_q1.aggregate()
 
     assert report["status"] == "PASS"
+    assert report["schema"] == "trendmarketv2.q1.boss.report"
+    assert report["schema_version"] == aggregate_q1.SCHEMA_VERSION
     guard_status = (
         (aggregate_q1.OUTPUT_DIR / "guard_status.txt")
         .read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- normalize boss final schema metadata by extracting the version suffix and defaulting to boss_final.report@1 when missing
- ensure the local and remote aggregation scripts emit schema_version alongside schema and teach evidence generation to surface it
- update regression tests and sample artifacts to assert the new contract

## Testing
- ruff check
- ruff format --check
- pytest -q

## Checklist
- [x] ruff ok
- [x] pytest ok
- [x] aggregate local ok
- [x] aggregate final ok
- [x] artefatos s1..s6 ok


------
https://chatgpt.com/codex/tasks/task_e_68ffff7682248330a44b0b138daab825