### PR TITLE
fix(boss): S1 Ruff PASS + schema guards no boss final (idempotent)

### DIFF
--- a/scripts/boss_final/aggregate_reports.py
+++ b/scripts/boss_final/aggregate_reports.py
@@ -219,6 +219,7 @@ def main() -> int:
         "generated_at": _now_utc(),
         "stages": stages,
         "summary": {"counts": summary_counts},
+        "status": final_status,
     }
     ensure_schema_metadata(report)
     report_path = os.path.join(out_dir, "report.json")

--- a/scripts/boss_final/ensure_schema.py
+++ b/scripts/boss_final/ensure_schema.py
@@ -3,11 +3,12 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import pathlib
 import re
-from datetime import datetime, timezone
+from typing import Any, MutableMapping
 
 MANDATORY = ("schema", "schema_version", "timestamp_utc", "generated_at", "status")
 
@@ -21,7 +22,15 @@ def _find_candidate() -> pathlib.Path:
     return candidates[0]
 
 
-def _infer_version(data: dict) -> int:
+def _schema_version_default() -> int:
+    raw = os.environ.get("BOSS_SCHEMA_VERSION", "1")
+    try:
+        return int(raw.strip() or "1")
+    except (TypeError, ValueError):
+        return 1
+
+
+def _infer_version(data: MutableMapping[str, Any]) -> int:
     version = None
     s = data.get("schema")
     if isinstance(s, str):
@@ -36,40 +45,57 @@ def _infer_version(data: dict) -> int:
             version = int(str(data.get("schema_version")))
         except Exception:
             version = None
-    return version or 1
+    return version or _schema_version_default()
 
 
 def _now_utc_z() -> str:
     return (
-        datetime.now(timezone.utc)
+        datetime.datetime.now(datetime.timezone.utc)
         .replace(microsecond=0)
         .isoformat()
         .replace("+00:00", "Z")
     )
 
 
-def _ensure_fields(path: pathlib.Path) -> None:
-    data = json.loads(path.read_text(encoding="utf-8"))
+def ensure_schema_metadata(data: MutableMapping[str, Any]) -> bool:
     changed = False
 
+    schema_version = data.get("schema_version")
+    if not schema_version:
+        data["schema_version"] = _schema_version_default()
+        changed = True
+
     version = _infer_version(data)
+
     schema_value = data.get("schema")
     if not isinstance(schema_value, str) or "boss_final.report@" not in schema_value:
         data["schema"] = f"boss_final.report@{version}"
         changed = True
+
     if str(data.get("schema_version")) != str(version):
         data["schema_version"] = version
         changed = True
 
-    if not data.get("timestamp_utc"):
+    timestamp = data.get("timestamp_utc")
+    if not timestamp:
         data["timestamp_utc"] = _now_utc_z()
-        changed = True
-    if not data.get("generated_at"):
-        data["generated_at"] = data["timestamp_utc"]
+        timestamp = data["timestamp_utc"]
         changed = True
 
-    if not data.get("status"):
-        default_status = os.environ.get("BOSS_LOCAL_STATUS", "PASS").strip().upper() or "PASS"
+    if not data.get("generated_at"):
+        data["generated_at"] = timestamp
+        changed = True
+
+    status = data.get("status")
+    if isinstance(status, str) and status.strip():
+        normalized = status.strip().upper()
+        if normalized != status:
+            data["status"] = normalized
+            changed = True
+    else:
+        default_status = (
+            os.environ.get("BOSS_LOCAL_STATUS", "PASS").strip().upper() or "PASS"
+        )
         data["status"] = default_status
         changed = True
 
@@ -78,6 +104,13 @@ def _ensure_fields(path: pathlib.Path) -> None:
         raise SystemExit(
             f"[ensure-schema] campos obrigatórios ausentes após normalização: {', '.join(missing)}"
         )
+
+    return changed
+
+
+def _ensure_fields(path: pathlib.Path) -> None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    changed = ensure_schema_metadata(data)
 
     if changed:
         path.write_text(

--- a/tests/boss_final/test_aggregate_local_schema.py
+++ b/tests/boss_final/test_aggregate_local_schema.py
@@ -30,7 +30,7 @@ def _find_report() -> pathlib.Path:
     return candidates[0]
 
 
-def test_local_aggregate_contains_schema(
+def test_required_fields(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
@@ -61,3 +61,5 @@ def test_local_aggregate_contains_schema(
         "Campo `schema_version` ausente ou inválido"
     )
     assert "generated_at" in data, "`generated_at` ausente"
+    assert "timestamp_utc" in data, "`timestamp_utc` ausente"
+    assert data.get("status") == "PASS", "`status` ausente ou inválido"


### PR DESCRIPTION
Resolve gate vermelho em S1 causado por ruff format pendente em ensure_schema.py e consolida garantias de schema (schema_version, timestamp_utc, status) no boss-final-report. Inclui varredura de formatação repo-wide se necessário. Todos os testes/guards VERDES.

------
https://chatgpt.com/codex/tasks/task_e_6900179b3c448330be26f76b5dffa504