### PR TITLE
S1 — Ruff format: aplicar formatação exigida (ensure_schema.py, test_aggregate_q1.py)

### DIFF
--- a/scripts/boss_final/ensure_schema.py
+++ b/scripts/boss_final/ensure_schema.py
@@ -104,10 +104,9 @@ def ensure_schema_metadata(data: MutableMapping[str, Any]) -> dict[str, Any]:
 
     bundle_info = normalized.get("bundle")
     required_bundle_keys = {"path", "sha256", "size_bytes"}
-    has_complete_bundle = (
-        isinstance(bundle_info, MutableMapping)
-        and required_bundle_keys.issubset(bundle_info.keys())
-    )
+    has_complete_bundle = isinstance(
+        bundle_info, MutableMapping
+    ) and required_bundle_keys.issubset(bundle_info.keys())
 
     boss_out_dir = pathlib.Path(os.environ.get("BOSS_OUT_DIR", "out/boss"))
     bundle_override = os.environ.get("BOSS_BUNDLE_PATH")
@@ -121,7 +120,9 @@ def ensure_schema_metadata(data: MutableMapping[str, Any]) -> dict[str, Any]:
         stage_zips = sorted(boss_out_dir.glob("boss-stage-*.zip"))
         if stage_zips:
             bundle_path.parent.mkdir(parents=True, exist_ok=True)
-            with zipfile.ZipFile(bundle_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            with zipfile.ZipFile(
+                bundle_path, "w", compression=zipfile.ZIP_DEFLATED
+            ) as archive:
                 for stage_zip in stage_zips:
                     archive.write(stage_zip, arcname=stage_zip.name)
 

--- a/tests/boss_final/test_aggregate_q1.py
+++ b/tests/boss_final/test_aggregate_q1.py
@@ -37,7 +37,9 @@ def _prepare_bundle_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
     boss_out_dir.mkdir(parents=True, exist_ok=True)
     for stage in STAGES:
         bundle_path = boss_out_dir / f"boss-stage-{stage}.zip"
-        with zipfile.ZipFile(bundle_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        with zipfile.ZipFile(
+            bundle_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as archive:
             archive.writestr("manifest.json", json.dumps({"stage": stage}))
     return boss_out_dir
 


### PR DESCRIPTION
• Problema: Stage S1 reprova em “Ruff format (exit 1)” por diffs de formatação em dois arquivos.
• Solução: Aplicada a formatação automática via Ruff 0.12.11 e confirmados manualmente os dois trechos destacados pelo job. Sem alterações semânticas.
• Testes: py_compile OK; ruff check & ruff format --check OK; pytest -k bundle OK.
• Risco: Nulo (formatação apenas).
• DoD: S1 verde, Aggregate Boss Final verde.

------
https://chatgpt.com/codex/tasks/task_e_6900312da35883308a1933a2c85a9a71