### PR TITLE
Garante inferência do bundle do Boss Final

### DIFF
--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -52,3 +52,35 @@ jobs:
       run_sim: ${{ inputs.run_sim }}
       run_dbt_ci: ${{ inputs.run_dbt_ci }}
     secrets: inherit
+
+  aggregate-boss-final:
+    name: "Aggregate Boss Final"
+    runs-on: ubuntu-22.04
+    needs: [call-orr]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Preparar zips de estágio → out/boss
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p out/boss
+          found=false
+          while IFS= read -r -d '' z; do
+            cp -v "$z" out/boss/ || true
+            found=true
+          done < <(find . -type f -name 'boss-stage-*.zip' -print0 || true)
+          ls -l out/boss || true
+          if [ "$found" = false ]; then
+            echo "[aggregate-boss] aviso: nenhum boss-stage-*.zip encontrado no workspace; ensure_schema fará rglob."
+          fi
+
+      - name: Aggregate reports (local)
+        shell: bash
+        env:
+          BOSS_OUT_DIR: out/boss
+          BOSS_STAGE_GLOB: boss-stage-*.zip
+        run: |
+          set -euo pipefail
+          python -m scripts.boss_final.aggregate_reports_local


### PR DESCRIPTION
## Summary
- garante que `ensure_schema` reconstrói ou usa o bundle final via overrides e busca recursiva pelos zips dos estágios
- ajusta `aggregate_reports_local` para copiar artefatos de estágio para `out/boss`, propagar variáveis e manter compatibilidade
- adiciona job dedicado de agregação no workflow S4 e testes cobrindo os caminhos padrão, `BOSS_STAGE_DIR` e `BOSS_BUNDLE_PATH`

## Testing
- `ruff format --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_69003775260c833096b4f3de4f23c738