### PR TITLE
boss-final: pin workflows to SHAs (fix S4 PINS) + bundle schema sha256-only

### DIFF
--- a/.github/workflows/_crd-orr.yml
+++ b/.github/workflows/_crd-orr.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
 
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload ORR bundle
 
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: obs-bundle-${{ inputs.profile }}-${{ inputs.environment }}
           path: |

--- a/.github/workflows/_mbp-s2-orr.yml
+++ b/.github/workflows/_mbp-s2-orr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Tooling versions
         shell: bash
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Publicar artefatos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: orr-evidence
           path: out/orr_gatecheck/evidence

--- a/.github/workflows/_mbp-s3-orr.yml
+++ b/.github/workflows/_mbp-s3-orr.yml
@@ -7,7 +7,7 @@ jobs:
   orr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Tooling versions
         run: |
           bash --version | head -n1 || true
@@ -36,7 +36,7 @@ jobs:
             echo "FREEZE=NO — ok para prosseguir"
           fi
       - name: Publicar artefatos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: s3-evidence
           path: out/s3_gatecheck/evidence

--- a/.github/workflows/_run-s3-command.yml
+++ b/.github/workflows/_run-s3-command.yml
@@ -10,7 +10,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: sudo apt-get update && sudo apt-get install -y python3 jq
       - run: |
           set -euo pipefail
@@ -19,7 +19,7 @@ jobs:
           eval ${{ github.event.inputs.cmd }} | tee /tmp/cmd.out
           echo "---"
           echo "Conteúdo de out/s3_gatecheck:"; ls -la out/s3_gatecheck || true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: s3-run-output
           path: |

--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ inputs.ref || github.sha }}
 
@@ -199,7 +199,7 @@ jobs:
 
       - name: Security | Upload findings
         if: ${{ always() && inputs.run_security }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: security-findings
           path: out/security/**
@@ -263,7 +263,7 @@ jobs:
 
       - name: GHCR login (opcional)
         if: ${{ inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' && steps.ghcr_tok.outputs.has_token == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@f4ef339be1f7c0066db2ed1d1c637d705d7d76e8
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -347,7 +347,7 @@ jobs:
           exit "$RC"
 
       - name: Upload TLA report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ always() && inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' }}
         with:
           name: tla-report
@@ -483,7 +483,7 @@ jobs:
 
       - name: Upload dbt docs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: s4-dbt-docs
           path: analytics/dbt/target
@@ -491,7 +491,7 @@ jobs:
 
       - name: Upload bundle
         if: ${{ always() && !inputs.run_tla }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: s5-bundle
           path: |
@@ -504,7 +504,7 @@ jobs:
 
       - name: Upload auditoria pip
         if: ${{ always() && !inputs.run_tla }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: pip-audit
           path: out/pip-audit
@@ -512,7 +512,7 @@ jobs:
 
       - name: Upload s5-orr evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: s5-orr-evidence
           path: |

--- a/.github/workflows/canary-sampler.yml
+++ b/.github/workflows/canary-sampler.yml
@@ -4,7 +4,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Sample 100 users
         shell: bash
         run: |

--- a/.github/workflows/crd-epic-plan.yml
+++ b/.github/workflows/crd-epic-plan.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Resolver inputs (IssueOps)
         id: io
@@ -97,7 +97,7 @@ jobs:
           echo "PLAN_OK"
 
       - name: Publicar artefatos (plan)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: crd-epic-plan-${{ github.ref_name }}-${{ github.run_id }}
           path: ${{ steps.io.outputs.out_dir }}/

--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -55,8 +55,8 @@ jobs:
       CLEAN_RUNNER: 'false'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: "3.11"
           check-latest: true
@@ -115,7 +115,7 @@ jobs:
           ls -lh "$zip_path"
       - name: Upload stage artifact (zip)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: boss-stage-${{ env.STAGE }}
           path: out/boss/boss-stage-${{ env.STAGE }}.zip
@@ -135,7 +135,7 @@ jobs:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Python + venv + deps
         uses: ./.github/actions/setup-python-venv
 
@@ -148,7 +148,7 @@ jobs:
 
       - name: Download stage artifacts
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: boss-stage-*
           merge-multiple: true
@@ -233,7 +233,7 @@ jobs:
 
       - name: Upload Boss Final aggregate
         if: steps.aggregate.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: boss-final-aggregate
           path: |

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload guard report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: repo-guard-report
           path: out/repo_guard/**/*.txt

--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -59,7 +59,7 @@ jobs:
     needs: [call-orr]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Preparar zips de estágio → out/boss
         shell: bash

--- a/.github/workflows/s5-validation.yml
+++ b/.github/workflows/s5-validation.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ inputs.ref || github.sha }}
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Sprint 5 artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sprint5-validation-artifacts
           path: |

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -45,7 +45,7 @@ jobs:
       CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install Python 3.11
         run: |
@@ -208,7 +208,7 @@ jobs:
         run: python scripts/scorecards/s6_scorecards.py
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: s6-scorecards
           path: ${{ env.REPORT_DIR }}

--- a/.github/workflows/sanity-actions.yml
+++ b/.github/workflows/sanity-actions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Verify action pins and existence
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,8 +11,8 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: returntocorp/semgrep-action@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: returntocorp/semgrep-action@d2118d8864c8ad5ac2ffb5f062e30aea0a43d0f0
         with:
           config: p/ci
           generateSarif: true

--- a/.github/workflows/shadow-toggle.yml
+++ b/.github/workflows/shadow-toggle.yml
@@ -19,7 +19,7 @@ jobs:
   toggle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Atualizar configs/shadow.env
         run: |
           mkdir -p configs

--- a/scripts/boss_final/aggregate_reports_local.py
+++ b/scripts/boss_final/aggregate_reports_local.py
@@ -181,10 +181,7 @@ def main() -> int:
 
     bundle_path = _build_or_locate_bundle(boss_out_dir)
     if "bundle" not in aggregate and bundle_path and bundle_path.exists():
-        aggregate["bundle"] = {
-            "path": str(bundle_path),
-            "sha256": _sha256(bundle_path),
-        }
+        aggregate["bundle"] = {"sha256": _sha256(bundle_path)}
 
     report = ensure_schema_metadata(aggregate)
     for key in ("summary", "generated_at"):

--- a/scripts/dev/patch_actions_to_sha.py
+++ b/scripts/dev/patch_actions_to_sha.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+
+LOCK_PATHS = [
+    Path('out/guard/s4/actions_lock_report.json'),
+    Path('.github/actions.lock'),
+]
+
+def load_lock() -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for path in LOCK_PATHS:
+        if not path.exists():
+            continue
+        if path.suffix == '.json':
+            data = json.loads(path.read_text(encoding='utf-8'))
+            actions = data.get('actions', [])
+            for entry in actions:
+                repo = str(entry.get('repo', '')).strip().lower()
+                sha = str(entry.get('sha', '')).strip()
+                if repo and sha:
+                    mapping[repo] = sha
+        else:
+            # simple parser for YAML lock with lines "key: repo@ref" and "commit: sha"
+            repo = None
+            for line in path.read_text(encoding='utf-8').splitlines():
+                line = line.strip()
+                if line.startswith('key:') and '@' in line:
+                    repo = line.split(':', 1)[1].strip().split('@', 1)[0].lower()
+                elif line.startswith('commit:') and repo:
+                    sha = line.split(':', 1)[1].strip()
+                    if repo and sha:
+                        mapping[repo] = sha
+                        repo = None
+    return mapping
+
+RE_USES = re.compile(
+    r'^(?P<prefix>\s*-?\s*uses:\s*)(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@(?P<ref>[^\s#]+)(?P<suffix>.*)$'
+)
+RE_PIN_COMMENT = re.compile(r'\s+#\s*pinned\s*\(was.*\)\s*$', re.IGNORECASE)
+
+
+def main() -> int:
+    mapping = load_lock()
+    if not mapping:
+        raise SystemExit('no lock mapping found')
+
+    changed_files = 0
+    for wf in sorted(Path('.github/workflows').glob('*.yml')) + sorted(Path('.github/workflows').glob('*.yaml')):
+        original = wf.read_text(encoding='utf-8')
+        lines = original.splitlines()
+        updated = []
+        modified = False
+        for line in lines:
+            m = RE_USES.match(line)
+            if m:
+                repo = m.group('repo')
+                key = repo.lower()
+                sha = mapping.get(key)
+                if sha and sha != m.group('ref'):
+                    line = f"{m.group('prefix')}{repo}@{sha}{m.group('suffix')}"
+                    modified = True
+                # Remove pinned comments regardless of replacement
+                new_line = RE_PIN_COMMENT.sub('', line)
+                if new_line != line:
+                    modified = True
+                line = new_line
+            updated.append(line)
+        if modified:
+            wf.write_text('\n'.join(updated) + '\n', encoding='utf-8')
+            changed_files += 1
+    print(f'[patch] arquivos alterados: {changed_files}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace every GitHub Actions `uses:` tag in `.github/workflows/` with the matching 40-hex SHA from the existing lock so S4-PINS accepts the YAML
- keep the Boss Final bundle contract sha256-only and generate a helper patch script to make pinning idempotent locally

## Testing
- pytest -q tests/boss_final -k 'aggregate or sprint_guard' --maxfail=1

## Boss Final Guards
- S1 – PASS (unchanged)
- S2 – PASS (unchanged)
- S3 – PASS (unchanged)
- S4 – PASS (YAML now pinned to lock SHAs, `@v*` tags removed)
- S5 – PASS (unchanged)
- S6 – PASS (unchanged)
- Aggregate – PASS (boss-final-report.json bundle now only exposes `sha256`)


------
https://chatgpt.com/codex/tasks/task_e_6901453875708330be5251620f6f5927