### PR TITLE
Fix Boss Final schema and harden action pin enforcement

### DIFF
--- a/.github/scripts/gen_actions_lock.py
+++ b/.github/scripts/gen_actions_lock.py
@@ -1,106 +1,382 @@
 #!/usr/bin/env python3
+"""Generate actions.lock with validated GitHub Action pins."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
 import json
 import os
-import pathlib
 import re
+import subprocess
 import sys
+import urllib.error
 import urllib.request
-from typing import Dict, Optional
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
 
-ROOT = pathlib.Path(__file__).resolve().parents[2]
-WF_DIR = ROOT / ".github" / "workflows"
-OUT_DIR = ROOT / "out" / "guard" / "s4"
-OUT_DIR.mkdir(parents=True, exist_ok=True)
-LOCK_PATH = OUT_DIR / "actions.lock.json"
-GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
-
-USES_RE = re.compile(
-    r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)@(?P<ref>[A-Za-z0-9_.-]+)$"
-)
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WORKFLOWS_DIR = ROOT / ".github" / "workflows"
+DEFAULT_OUTPUT_PATH = ROOT / "actions.lock"
+DEFAULT_EVIDENCE_PATH = ROOT / "out" / "guard" / "s4" / "actions.lock.json"
 HEX40_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+ACTION_PATTERN = re.compile(
+    r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)"
+    r"(?P<path>(?:/[A-Za-z0-9_.\-/]+)?)@(?P<ref>[^\s@]+)$"
+)
+USER_AGENT = "trendmarketv2-actions-lock-generator"
+
+try:  # Prefer PyYAML, fallback to bundled parser when unavailable
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for minimal environments
+    sys.path.append(str(ROOT))
+    import yaml_fallback as yaml  # type: ignore
 
 
-def gh_api(url: str) -> dict:
-    req = urllib.request.Request(url)
-    if GITHUB_TOKEN:
-        req.add_header("Authorization", f"Bearer {GITHUB_TOKEN}")
-    req.add_header("Accept", "application/vnd.github+json")
-    with urllib.request.urlopen(req, timeout=30) as r:
-        return json.loads(r.read().decode("utf-8"))
+@dataclass
+class ActionUsage:
+    owner: str
+    repo: str
+    path: str
+    ref: str
+    workflows: List[str]
+
+    @property
+    def repo_key(self) -> str:
+        return (
+            f"{self.owner}/{self.repo}{self.path}"
+            if self.path
+            else f"{self.owner}/{self.repo}"
+        )
 
 
-def resolve_tag_to_sha(owner: str, repo: str, ref: str) -> Optional[str]:
-    # Tenta refs/tags/{ref}; se apontar para annotated tag, segue o objeto
+class GitHubAPIError(RuntimeError):
+    """Raised when the GitHub API request fails."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+
+
+def isoformat_utc(value: dt.datetime | None = None) -> str:
+    value = value or utc_now()
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def gh_api(url: str, token: str | None) -> dict:
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("User-Agent", USER_AGENT)
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
     try:
-        data = gh_api(f"https://api.github.com/repos/{owner}/{repo}/git/ref/tags/{ref}")
-        obj = data.get("object", {})
-        if obj.get("type") == "tag":
-            tagobj = gh_api(
-                f"https://api.github.com/repos/{owner}/{repo}/git/tags/{obj['sha']}"
-            )
-            return tagobj.get("object", {}).get("sha")
-        return obj.get("sha")
-    except Exception:
-        # fallback: lista tags e tenta casar
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
+        message = exc.read().decode("utf-8", errors="ignore")
+        raise GitHubAPIError(exc.code, message)
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure path
+        raise GitHubAPIError(0, str(exc))
+
+
+def _ls_remote(url: str, pattern: str) -> Dict[str, str]:
+    proc = subprocess.run(
+        ["git", "ls-remote", url, pattern],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return {}
+    entries: Dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
         try:
-            tags = gh_api(
-                f"https://api.github.com/repos/{owner}/{repo}/tags?per_page=200"
-            )
-            for t in tags:
-                if t.get("name") == ref and t.get("commit", {}).get("sha"):
-                    return t["commit"]["sha"]
-        except Exception:
-            return None
+            sha, name = line.split("\t", 1)
+        except ValueError:
+            continue
+        entries[name] = sha.lower()
+    return entries
+
+
+def _candidate_patterns(ref: str) -> List[str]:
+    patterns = [ref]
+    if not ref.startswith("refs/"):
+        patterns.extend(
+            [
+                f"{ref}^{{}}",
+                f"refs/tags/{ref}",
+                f"refs/tags/{ref}^{{}}",
+                f"refs/heads/{ref}",
+            ]
+        )
+    elif not ref.endswith("^{}"):
+        patterns.append(f"{ref}^{{}}")
+    return patterns
+
+
+def resolve_with_git(owner: str, repo: str, ref: str) -> str | None:
+    url = f"https://github.com/{owner}/{repo}.git"
+    for pattern in _candidate_patterns(ref):
+        mapping = _ls_remote(url, pattern)
+        if not mapping:
+            continue
+        for name, sha in mapping.items():
+            if name.endswith("^{}"):
+                return sha
+        normalized = pattern[:-3] if pattern.endswith("^{}") else pattern
+        for name, sha in mapping.items():
+            if name == normalized or name.endswith(f"/{normalized}"):
+                return sha
+        return next(iter(mapping.values()))
     return None
 
 
-def collect_uses() -> Dict[str, str]:
-    import yaml  # PyYAML disponível no runner
+def validate_commit(owner: str, repo: str, sha: str, token: str | None) -> bool:
+    url = f"https://api.github.com/repos/{owner}/{repo}/git/commits/{sha}"
+    try:
+        gh_api(url, token)
+    except GitHubAPIError as exc:
+        if exc.status in {404, 422}:
+            return False
+        raise
+    return True
 
-    uses = {}
-    for yml in sorted(WF_DIR.glob("*.yml")) + sorted(WF_DIR.glob("*.yaml")):
-        with open(yml, "r", encoding="utf-8", errors="ignore") as f:
-            try:
-                doc = yaml.safe_load(f) or {}
-            except Exception:
+
+def peel_to_commit(owner: str, repo: str, sha: str, token: str | None) -> str | None:
+    current = sha
+    seen: set[str] = set()
+    while current and current not in seen:
+        seen.add(current)
+        if validate_commit(owner, repo, current, token):
+            return current.lower()
+        try:
+            tag_data = gh_api(
+                f"https://api.github.com/repos/{owner}/{repo}/git/tags/{current}",
+                token,
+            )
+        except GitHubAPIError as exc:
+            if exc.status in {404, 422}:
+                return None
+            raise
+        next_sha = tag_data.get("object", {}).get("sha")
+        if not isinstance(next_sha, str):
+            return None
+        current = next_sha
+    return None
+
+
+def resolve_reference(
+    owner: str, repo: str, ref: str, token: str | None
+) -> Tuple[str, str]:
+    if HEX40_RE.fullmatch(ref):
+        sha = ref.lower()
+        if not validate_commit(owner, repo, sha, token):
+            raise RuntimeError(f"{owner}/{repo}@{ref} is not a valid commit SHA")
+        source = "sha"
+    else:
+        resolved = resolve_with_git(owner, repo, ref)
+        if not resolved:
+            raise RuntimeError(
+                f"Unable to resolve {owner}/{repo}@{ref} via git ls-remote"
+            )
+        peeled = peel_to_commit(owner, repo, resolved, token)
+        if not peeled:
+            raise RuntimeError(
+                f"Unable to peel {owner}/{repo}@{ref} to a commit (resolved {resolved})"
+            )
+        sha = peeled
+        source = "ref"
+    return sha, source
+
+
+def collect_uses(workflows_dir: Path) -> Dict[Tuple[str, str, str, str], ActionUsage]:
+    references: Dict[Tuple[str, str, str, str], ActionUsage] = {}
+    workflow_paths = sorted(workflows_dir.glob("*.yml")) + sorted(
+        workflows_dir.glob("*.yaml")
+    )
+    for workflow_path in workflow_paths:
+        try:
+            document = yaml.safe_load(workflow_path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:  # pragma: no cover - defensive parsing
+            print(f"[gen-lock] warning: failed to parse {workflow_path}: {exc}")
+            continue
+        jobs = document.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job in jobs.values():
+            steps = (job or {}).get("steps")
+            if not isinstance(steps, Iterable):
                 continue
-        for job in (doc.get("jobs") or {}).values():
-            for step in job.get("steps") or []:
-                u = (step or {}).get("uses")
-                if not u:
+            for step in steps:
+                if not isinstance(step, dict):
                     continue
-                if str(u).startswith("./") or str(u).startswith(".\\"):
-                    continue  # ação local
-                if str(u).startswith("docker://"):
-                    continue  # imagens docker não entram no lock
-                m = USES_RE.match(str(u).strip())
-                if not m:
+                value = step.get("uses")
+                if not value:
                     continue
-                key = f"{m.group('owner')}/{m.group('repo')}"
-                uses[key] = m.group("ref")
-    return uses
+                uses_value = str(value).strip()
+                if uses_value.startswith("./") or uses_value.startswith("docker://"):
+                    continue
+                match = ACTION_PATTERN.match(uses_value)
+                if not match:
+                    continue
+                owner = match.group("owner")
+                repo = match.group("repo")
+                path = match.group("path") or ""
+                ref = match.group("ref")
+                key = (owner, repo, path, ref)
+                usage = references.get(key)
+                if usage is None:
+                    usage = ActionUsage(
+                        owner=owner,
+                        repo=repo,
+                        path=path,
+                        ref=ref,
+                        workflows=[],
+                    )
+                    references[key] = usage
+                rel_path = str(workflow_path.relative_to(ROOT))
+                if rel_path not in usage.workflows:
+                    usage.workflows.append(rel_path)
+    for usage in references.values():
+        usage.workflows.sort()
+    return references
 
 
-def main() -> int:
-    uses = collect_uses()
-    lock: Dict[str, Dict[str, str]] = {}
-    for key, ref in sorted(uses.items()):
-        owner, repo = key.split("/")
-        if HEX40_RE.match(ref):
-            sha = ref.lower()
-        else:
-            sha = resolve_tag_to_sha(owner, repo, ref)
-            if not sha:
-                print(f"[gen-lock] Falha ao resolver {key}@{ref}", file=sys.stderr)
-                return 2
-        lock[key] = {"ref": ref, "sha": sha}
-    tmp = LOCK_PATH.with_suffix(".tmp.json")
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(lock, f, indent=2, sort_keys=True)
-    os.replace(tmp, LOCK_PATH)
-    print(f"[gen-lock] lock escrito em {LOCK_PATH}")
+def compute_metadata_sha(actions: List[Dict[str, str]]) -> str:
+    payload = json.dumps(actions, sort_keys=True).encode("utf-8")
+    return hashlib.sha1(payload).hexdigest()
+
+
+def build_actions_list(
+    usages: Dict[Tuple[str, str, str, str], ActionUsage],
+    *,
+    author: str,
+    rationale: str,
+    token: str | None,
+) -> List[Dict[str, str]]:
+    actions: List[Dict[str, str]] = []
+    timestamp = isoformat_utc()
+    for key in sorted(usages, key=lambda item: (item[0], item[1], item[2], item[3])):
+        usage = usages[key]
+        sha, source = resolve_reference(usage.owner, usage.repo, usage.ref, token)
+        repo_key = usage.repo_key
+        print(f"[gen-lock] {repo_key}@{usage.ref} -> {sha} ({source})")
+        actions.append(
+            {
+                "repo": repo_key,
+                "ref": usage.ref,
+                "sha": sha,
+                "date": timestamp,
+                "author": author,
+                "rationale": rationale,
+                "url": f"https://github.com/{usage.owner}/{usage.repo}/commit/{sha}",
+            }
+        )
+    return actions
+
+
+def write_outputs(
+    lock_data: Dict[str, object],
+    *,
+    output_path: Path,
+    evidence_path: Path,
+) -> None:
+    text = json.dumps(lock_data, indent=2) + "\n"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(text, encoding="utf-8")
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(text, encoding="utf-8")
+    print(f"[gen-lock] wrote {output_path}")
+    if evidence_path != output_path:
+        print(f"[gen-lock] evidence copy at {evidence_path}")
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workflows",
+        type=Path,
+        default=DEFAULT_WORKFLOWS_DIR,
+        help="Directory containing workflow files (default: .github/workflows)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Destination path for actions.lock (default: actions.lock)",
+    )
+    parser.add_argument(
+        "--evidence",
+        type=Path,
+        default=DEFAULT_EVIDENCE_PATH,
+        help="Path to write a copy for guard evidence (default: out/guard/s4/actions.lock.json)",
+    )
+    parser.add_argument(
+        "--author",
+        type=str,
+        default="CI Bot <ci@trendmarketv2.local>",
+        help="Author recorded in the lock metadata",
+    )
+    parser.add_argument(
+        "--rationale",
+        type=str,
+        default="auto-sync action pins for workflow consistency",
+        help="Rationale recorded in the lock metadata",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+    workflows_dir = (
+        (ROOT / args.workflows).resolve()
+        if not args.workflows.is_absolute()
+        else args.workflows
+    )
+    output_path = (
+        (ROOT / args.out).resolve() if not args.out.is_absolute() else args.out
+    )
+    evidence_path = (
+        (ROOT / args.evidence).resolve()
+        if not args.evidence.is_absolute()
+        else args.evidence
+    )
+
+    usages = collect_uses(workflows_dir)
+    if not usages:
+        print("[gen-lock] no GitHub actions detected", file=sys.stderr)
+        return 1
+
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    try:
+        actions = build_actions_list(
+            usages, author=args.author, rationale=args.rationale, token=token
+        )
+    except RuntimeError as exc:
+        print(f"[gen-lock] error: {exc}", file=sys.stderr)
+        return 2
+
+    metadata = {
+        "sha": "",
+        "date": isoformat_utc(),
+        "author": args.author,
+        "rationale": args.rationale,
+    }
+    lock_data = {"version": 1, "metadata": metadata, "actions": actions}
+    metadata["sha"] = compute_metadata_sha(actions)
+
+    write_outputs(lock_data, output_path=output_path, evidence_path=evidence_path)
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/.github/scripts/verify_actions_lock.py
+++ b/.github/scripts/verify_actions_lock.py
@@ -1,90 +1,300 @@
 #!/usr/bin/env python3
+"""Validate actions.lock structure and pinned GitHub actions."""
+
+from __future__ import annotations
+
+import argparse
 import json
-import pathlib
+import os
 import re
 import sys
-from typing import Dict
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LOCK_PATH = ROOT / "actions.lock"
+DEFAULT_REPORT_PATH = ROOT / "out" / "guard" / "s4" / "actions_lock_report.json"
+HEX40_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+ACTION_PATTERN = re.compile(
+    r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)(?P<path>(?:/[A-Za-z0-9_.\-/]+)?)$"
+)
+USER_AGENT = "trendmarketv2-actions-lock-verify"
 
 try:  # Prefer PyYAML, fallback to bundled parser when unavailable
     import yaml  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - fallback path for minimal envs
-    sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+except ModuleNotFoundError:  # pragma: no cover - fallback for minimal environments
+    sys.path.append(str(ROOT))
     import yaml_fallback as yaml  # type: ignore
 
-ROOT = pathlib.Path(__file__).resolve().parents[2]
-WF_DIR = ROOT / ".github" / "workflows"
-OUT_DIR = ROOT / "out" / "guard" / "s4"
-LOCK_PATH = OUT_DIR / "actions.lock.json"
-REPORT = OUT_DIR / "actions_lock_report.json"
 
-USES_RE = re.compile(
-    r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)@(?P<ref>[A-Za-z0-9_.-]+)$"
-)
-HEX40_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+@dataclass
+class ValidationIssue:
+    scope: str
+    message: str
 
 
-def parse_uses() -> Dict[str, str]:
-    uses = {}
-    for yml in sorted(WF_DIR.glob("*.yml")) + sorted(WF_DIR.glob("*.yaml")):
-        with open(yml, "r", encoding="utf-8", errors="ignore") as f:
-            try:
-                doc = yaml.safe_load(f) or {}
-            except Exception:
+class GitHubAPIError(RuntimeError):
+    """Raised when the GitHub API request fails."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    value = value or datetime.now(timezone.utc).replace(microsecond=0)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def gh_api(url: str, token: str | None) -> dict:
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("User-Agent", USER_AGENT)
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
+        message = exc.read().decode("utf-8", errors="ignore")
+        raise GitHubAPIError(exc.code, message)
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure path
+        raise GitHubAPIError(0, str(exc))
+
+
+def validate_commit(
+    owner: str, repo: str, sha: str, token: str | None
+) -> Tuple[bool, str | None]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/git/commits/{sha}"
+    try:
+        payload = gh_api(url, token)
+    except GitHubAPIError as exc:
+        if exc.status in {404, 422}:
+            return False, None
+        raise
+    tree_sha = payload.get("sha") if isinstance(payload, dict) else None
+    return True, tree_sha
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "lock_path",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_LOCK_PATH,
+        help="Path to actions.lock (default: actions.lock)",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=DEFAULT_REPORT_PATH,
+        help="Path to write JSON report (default: out/guard/s4/actions_lock_report.json)",
+    )
+    return parser.parse_args(argv)
+
+
+def load_lock(path: Path) -> dict:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"unable to read {path}: {exc}") from exc
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:  # pragma: no cover - schema error path
+        raise RuntimeError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def collect_workflow_uses(workflows_dir: Path) -> List[Tuple[str, str]]:
+    results: List[Tuple[str, str]] = []
+    workflow_paths = sorted(workflows_dir.glob("*.yml")) + sorted(
+        workflows_dir.glob("*.yaml")
+    )
+    for workflow_path in workflow_paths:
+        try:
+            data = yaml.safe_load(workflow_path.read_text(encoding="utf-8")) or {}
+        except Exception:  # pragma: no cover - defensive parsing
+            continue
+        jobs = data.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job in jobs.values():
+            steps = (job or {}).get("steps")
+            if not isinstance(steps, Iterable):
                 continue
-        for job in (doc.get("jobs") or {}).values():
-            for step in job.get("steps") or []:
-                u = (step or {}).get("uses")
-                if not u:
+            for step in steps:
+                if not isinstance(step, dict):
                     continue
-                s = str(u).strip()
-                if s.startswith("./") or s.startswith("docker://"):
+                value = step.get("uses")
+                if not value:
                     continue
-                m = USES_RE.match(s)
-                if not m:
+                uses_value = str(value).strip()
+                if uses_value.startswith("./") or uses_value.startswith("docker://"):
                     continue
-                uses[f"{m.group('owner')}/{m.group('repo')}"] = m.group("ref")
-    return uses
+                results.append((str(workflow_path.relative_to(ROOT)), uses_value))
+    return results
 
 
-def main() -> int:
-    if not LOCK_PATH.exists():
-        print("[verify-lock] lock ausente", file=sys.stderr)
-        return 2
-    lock = json.loads(LOCK_PATH.read_text("utf-8"))
-    uses = parse_uses()
-    report = {"ok": True, "mismatches": []}
-    for key, ref in sorted(uses.items()):
-        locked_entry = lock.get(key)
-        if not locked_entry:
-            report["ok"] = False
-            report["mismatches"].append(
-                {"key": key, "reason": "ausente_no_lock", "ref": ref}
+def validate_lock_structure(lock: dict) -> List[ValidationIssue]:
+    issues: List[ValidationIssue] = []
+    if lock.get("version") != 1:
+        issues.append(ValidationIssue("metadata", "version must equal 1"))
+
+    metadata = lock.get("metadata")
+    if not isinstance(metadata, dict):
+        issues.append(ValidationIssue("metadata", "metadata must be an object"))
+    else:
+        for field in ("sha", "date", "author", "rationale"):
+            value = metadata.get(field)
+            if not isinstance(value, str) or not value.strip():
+                issues.append(ValidationIssue("metadata", f"{field} missing or empty"))
+        sha_value = metadata.get("sha")
+        if isinstance(sha_value, str) and not HEX40_RE.fullmatch(sha_value):
+            issues.append(
+                ValidationIssue("metadata", "metadata.sha must be 40 hex characters")
+            )
+        date_value = metadata.get("date")
+        if isinstance(date_value, str):
+            try:
+                datetime.fromisoformat(date_value.replace("Z", "+00:00"))
+            except ValueError:
+                issues.append(
+                    ValidationIssue("metadata", "metadata.date is not ISO-8601")
+                )
+
+    actions = lock.get("actions")
+    if not isinstance(actions, list) or not actions:
+        issues.append(ValidationIssue("actions", "actions list missing or empty"))
+
+    return issues
+
+
+def validate_actions_entries(
+    actions: List[dict],
+    token: str | None,
+) -> Tuple[List[ValidationIssue], int]:
+    issues: List[ValidationIssue] = []
+    checked = 0
+    for entry in actions:
+        if not isinstance(entry, dict):
+            issues.append(ValidationIssue("actions", "entry must be an object"))
+            continue
+        repo_value = entry.get("repo")
+        ref_value = entry.get("ref")
+        sha_value = entry.get("sha")
+        date_value = entry.get("date")
+        author_value = entry.get("author")
+        rationale_value = entry.get("rationale")
+        url_value = entry.get("url")
+        identifier = (
+            f"{repo_value}@{ref_value}" if repo_value and ref_value else str(repo_value)
+        )
+        for field_name, value in (
+            ("repo", repo_value),
+            ("ref", ref_value),
+            ("sha", sha_value),
+            ("date", date_value),
+            ("author", author_value),
+            ("rationale", rationale_value),
+            ("url", url_value),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                issues.append(
+                    ValidationIssue(identifier, f"field {field_name} missing")
+                )
+        if not isinstance(sha_value, str) or not HEX40_RE.fullmatch(sha_value):
+            issues.append(ValidationIssue(identifier, "sha must be a 40-character hex"))
+            continue
+        if not isinstance(repo_value, str) or not ACTION_PATTERN.match(repo_value):
+            issues.append(
+                ValidationIssue(identifier, "repo must follow owner/repo[/path]")
             )
             continue
-        sha = locked_entry.get("sha", "").lower()
-        if HEX40_RE.match(ref):
-            if ref.lower() != sha:
-                report["ok"] = False
-                report["mismatches"].append(
-                    {
-                        "key": key,
-                        "reason": "sha_divergente",
-                        "workflow": ref,
-                        "lock": sha,
-                    }
+        owner, repo, _ = ACTION_PATTERN.match(repo_value).groups()  # type: ignore[arg-type]
+        try:
+            valid, _ = validate_commit(owner, repo, sha_value.lower(), token)
+        except GitHubAPIError as exc:
+            issues.append(
+                ValidationIssue(
+                    identifier,
+                    f"failed to validate commit via API (status {exc.status})",
                 )
-        else:
-            # quando por tag, aceitamos desde que o lock possua um sha válido
-            if not sha:
-                report["ok"] = False
-                report["mismatches"].append(
-                    {"key": key, "reason": "sha_vazio_no_lock", "ref": ref}
-                )
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
-    REPORT.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
-    print(f"[verify-lock] relatório em {REPORT}")
-    return 0 if report["ok"] else 1
+            )
+            continue
+        if not valid:
+            issues.append(
+                ValidationIssue(identifier, "commit does not exist or is inaccessible")
+            )
+        checked += 1
+    return issues, checked
 
 
-if __name__ == "__main__":
+def validate_workflow_pins(workflows_dir: Path) -> List[ValidationIssue]:
+    issues: List[ValidationIssue] = []
+    for workflow, uses_value in collect_workflow_uses(workflows_dir):
+        if "@" not in uses_value:
+            issues.append(
+                ValidationIssue(workflow, f"uses entry without @: {uses_value}")
+            )
+            continue
+        ref = uses_value.split("@", 1)[1].strip()
+        if not HEX40_RE.fullmatch(ref):
+            issues.append(
+                ValidationIssue(workflow, f"reference not pinned to SHA: {uses_value}")
+            )
+    return issues
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+    lock_path = (
+        args.lock_path if args.lock_path.is_absolute() else (ROOT / args.lock_path)
+    ).resolve()
+    report_path = (
+        args.report if args.report.is_absolute() else (ROOT / args.report)
+    ).resolve()
+
+    try:
+        lock_data = load_lock(lock_path)
+    except RuntimeError as exc:
+        print(f"[verify-lock] error: {exc}", file=sys.stderr)
+        return 2
+
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+
+    issues = validate_lock_structure(lock_data)
+    actions = lock_data.get("actions")
+    checked_actions = 0
+    if isinstance(actions, list) and actions:
+        action_issues, checked_actions = validate_actions_entries(actions, token)
+        issues.extend(action_issues)
+    workflows_dir = ROOT / ".github" / "workflows"
+    issues.extend(validate_workflow_pins(workflows_dir))
+
+    report = {
+        "lock_path": str(lock_path.relative_to(ROOT)),
+        "checked_actions": checked_actions,
+        "issues": [
+            {"scope": issue.scope, "message": issue.message} for issue in issues
+        ],
+        "ok": not issues,
+        "generated_at": isoformat_utc(),
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"[verify-lock] report written to {report_path}")
+
+    if issues:
+        for issue in issues:
+            print(f"[verify-lock] {issue.scope}: {issue.message}", file=sys.stderr)
+        return 1
+    print("[verify-lock] actions.lock validated successfully")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/.github/scripts/verify_pins.py
+++ b/.github/scripts/verify_pins.py
@@ -1,28 +1,49 @@
+#!/usr/bin/env python3
+"""Validate that GitHub workflow steps use pinned action SHAs."""
+
+from __future__ import annotations
+
+import argparse
 import json
 import os
 import re
 import sys
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
 
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT_PATH = ROOT / "out" / "guard" / "s4" / "actions_pins_report.json"
+USER_AGENT = "trendmarketv2-actions-pins"
+HEX40_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 INLINE_RE = re.compile(
     r'^\s*(?:-\s*)?uses:\s*(["\']?)([\w_.-]+\/[\w_.-]+)@([^"\'\s#]+)\1\s*$'
 )
 KEY_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*$")
 VALUE_RE = re.compile(r'^\s*(["\']?)([\w_.-]+\/[\w_.-]+)@([^"\'\s#]+)\1\s*$')
-GITHUB_API = "https://api.github.com/repos/{repo}/commits/{ref}"
 
 
-def list_yaml_files(base_dir: str = ".github"):
+@dataclass
+class PinIssue:
+    file: str
+    line: int
+    repo: str
+    ref: str
+    reason: str
+
+
+def list_yaml_files(base_dir: Path) -> Iterable[Path]:
     for root, _, files in os.walk(base_dir):
         for filename in files:
             if filename.endswith((".yml", ".yaml")):
-                yield os.path.join(root, filename)
+                yield Path(root) / filename
 
 
-def extract_uses(path: str):
-    entries = []
-    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+def extract_uses(path: Path) -> List[Tuple[str, str, int]]:
+    entries: List[Tuple[str, str, int]] = []
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
         lines = handle.read().splitlines()
     idx = 0
     while idx < len(lines):
@@ -49,69 +70,106 @@ def extract_uses(path: str):
     return entries
 
 
-def http_status(repo: str, ref: str, headers: dict) -> int:
-    url = GITHUB_API.format(repo=repo, ref=ref)
-    request = urllib.request.Request(url, headers=headers)
+def commit_exists(repo: str, sha: str, token: str | None) -> bool:
+    url = f"https://api.github.com/repos/{repo}/git/commits/{sha}"
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("User-Agent", USER_AGENT)
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
     try:
-        with urllib.request.urlopen(request) as response:
-            return response.getcode()
+        with urllib.request.urlopen(request, timeout=30):
+            return True
     except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
-        return exc.code
-    except urllib.error.URLError:
-        return 0
+        if exc.code in {404, 422}:
+            return False
+        raise
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure path
+        raise RuntimeError(f"network error contacting GitHub: {exc}") from exc
 
 
-def build_summary(path: str, lines: list[str]):
-    if not path:
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=DEFAULT_REPORT_PATH,
+        help="Path to write JSON report (default: out/guard/s4/actions_pins_report.json)",
+    )
+    parser.add_argument(
+        "--base",
+        type=Path,
+        default=ROOT / ".github",
+        help="Base directory to scan for workflows (default: .github)",
+    )
+    return parser.parse_args(argv)
+
+
+def build_summary(summary_path: str, lines: List[str]) -> None:
+    if not summary_path:
         return
-    with open(path, "a", encoding="utf-8") as handle:
+    with open(summary_path, "a", encoding="utf-8") as handle:
         handle.write("\n".join(lines) + "\n")
 
 
-def main():
-    github_token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
-    headers = {
-        "User-Agent": "trendmarketv2-actions-sanity",
-        "Accept": "application/vnd.github+json",
-    }
-    if github_token:
-        headers["Authorization"] = f"Bearer {github_token}"
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+    report_path = (
+        args.report if args.report.is_absolute() else (ROOT / args.report)
+    ).resolve()
+    base_dir = args.base if args.base.is_absolute() else (ROOT / args.base)
 
-    files = sorted(list(list_yaml_files()))
-    occurrences = []
+    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+
+    files = sorted(list(list_yaml_files(base_dir)))
+    occurrences: List[Tuple[Path, str, str, int]] = []
     for file_path in files:
         for repo, ref, line in extract_uses(file_path):
             occurrences.append((file_path, repo, ref, line))
 
-    issues = []
-    checked_status: dict[tuple[str, str], int] = {}
-    sha_pattern = re.compile(r"^[0-9a-fA-F]{40}$")
+    issues: List[PinIssue] = []
+    checked_status: Dict[Tuple[str, str], bool] = {}
     for file_path, repo, ref, line in occurrences:
-        if not sha_pattern.fullmatch(ref):
+        if not HEX40_RE.fullmatch(ref):
             issues.append(
-                {
-                    "file": file_path,
-                    "line": line,
-                    "repo": repo,
-                    "ref": ref,
-                    "reason": "Ref não é SHA(40)",
-                }
+                PinIssue(
+                    file=str(file_path.relative_to(ROOT)),
+                    line=line,
+                    repo=repo,
+                    ref=ref,
+                    reason="reference is not a 40-character SHA",
+                )
             )
             continue
-        key = (repo, ref)
+        key = (repo, ref.lower())
         if key not in checked_status:
-            checked_status[key] = http_status(repo, ref, headers)
-        status = checked_status[key]
-        if status != 200:
+            try:
+                checked_status[key] = commit_exists(repo, ref.lower(), token)
+            except RuntimeError as exc:
+                print(f"[verify-pins] error: {exc}", file=sys.stderr)
+                return 2
+        if not checked_status[key]:
             issues.append(
-                {
-                    "file": file_path,
-                    "line": line,
-                    "repo": repo,
-                    "ref": ref,
-                    "reason": f"Commit inexistente ou inacessível (status {status})",
-                }
+                PinIssue(
+                    file=str(file_path.relative_to(ROOT)),
+                    line=line,
+                    repo=repo,
+                    ref=ref,
+                    reason="commit does not exist or is inaccessible",
+                )
             )
+
+    report = {
+        "generated_at": os.environ.get("GITHUB_RUN_ID") or "local",
+        "files": len(files),
+        "references": len(occurrences),
+        "checked_commits": len(checked_status),
+        "issues": [issue.__dict__ for issue in issues],
+        "ok": not issues,
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"[verify-pins] report written to {report_path}")
 
     summary_lines = [
         "### Sanity — Actions Pins",
@@ -121,38 +179,27 @@ def main():
         f"* Commits consultados: {len(checked_status)}",
         "",
     ]
-
     if issues:
         summary_lines.append("**Problemas encontrados:**")
-        for entry in issues:
+        for entry in issues[:20]:
             summary_lines.append(
-                f"- `{entry['repo']}@{entry['ref']}` em `{entry['file']}` (linha {entry['line']}): {entry['reason']}"
+                f"- `{entry.repo}@{entry.ref}` em `{entry.file}` (linha {entry.line}): {entry.reason}"
             )
+        if len(issues) > 20:
+            summary_lines.append(f"- ... (+{len(issues) - 20} ocorrências)")
     else:
-        summary_lines.append(
-            "Tudo OK — todas as actions usam SHAs de 40 caracteres válidos."
-        )
+        summary_lines.append("Tudo OK — todas as actions usam SHAs válidos.")
 
     build_summary(os.getenv("GITHUB_STEP_SUMMARY", ""), summary_lines)
 
     if issues:
         for entry in issues:
-            print(
-                json.dumps(
-                    {
-                        "file": entry["file"],
-                        "line": entry["line"],
-                        "action": entry["repo"],
-                        "ref": entry["ref"],
-                        "reason": entry["reason"],
-                    },
-                    ensure_ascii=False,
-                )
-            )
-        sys.exit(1)
+            print(json.dumps(entry.__dict__, ensure_ascii=False))
+        return 1
 
     print("OK")
+    return 0
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: GHCR login (opcional)
         if: ${{ inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' && steps.ghcr_tok.outputs.has_token == 'true' }}
-        uses: docker/login-action@f4ef339be1f7c0066db2ed1d1c637d705d7d76e8  # pinned (was v3)
+        uses: docker/login-action@e995cd7a8f6f9b877a4c1a27820f3e397985f9f2  # pinned (was v3)
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -187,6 +187,18 @@ jobs:
         run: |
           set -euo pipefail
           . .venv/bin/activate 2>/dev/null || true
+          python - <<'PY'
+from pathlib import Path
+import json
+
+from scripts.boss_final.ensure_schema import expected_schema_id
+
+report_path = Path("$REPORT_DIR") / "report.json"
+data = json.loads(report_path.read_text(encoding="utf-8"))
+expected = expected_schema_id()
+actual = data.get("schema")
+print(f"[boss-final] expected schema={expected} | current={actual}")
+PY
           python scripts/boss_final/ensure_schema.py "$REPORT_DIR/report.json"
 
       - name: Validate report schema (local)

--- a/.github/workflows/sanity-actions.yml
+++ b/.github/workflows/sanity-actions.yml
@@ -18,4 +18,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          python .github/scripts/verify_pins.py
+          python .github/scripts/verify_pins.py --report out/guard/s4/actions_pins_report.json
+      - name: Upload pins report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # pinned (was v4)
+        with:
+          name: sanity-actions-pins
+          path: out/guard/s4/actions_pins_report.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,4 +1,4 @@
-name: Semgrep (container)
+name: Semgrep (CLI)
 on:
   pull_request:
     branches: [ main ]
@@ -11,8 +11,34 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
-      - uses: returntocorp/semgrep-action@d2118d8864c8ad5ac2ffb5f062e30aea0a43d0f0  # pinned (was v1)
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+      - name: Setup Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # pinned (was v5)
         with:
-          config: p/ci
-          generateSarif: true
+          python-version: "3.11"
+          check-latest: true
+      - name: Install Semgrep CLI
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install semgrep==1.67.0
+      - name: Run Semgrep
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p out/guard/s4
+          if [ -n "${SEMGREP_APP_TOKEN:-}" ]; then
+            semgrep ci --config p/ci --sarif --output out/guard/s4/semgrep.sarif
+          else
+            semgrep scan --config p/ci --severity ERROR --error --sarif --output out/guard/s4/semgrep.sarif
+          fi
+      - name: Upload Semgrep results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # pinned (was v4)
+        with:
+          name: semgrep-sarif
+          path: out/guard/s4/semgrep.sarif
+          if-no-files-found: warn
+          retention-days: 7

--- a/actions.lock
+++ b/actions.lock
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "metadata": {
-    "sha": "3577ad7aee8b6f8f935c8389c0e37a5210d1a609",
-    "date": "2025-10-27T20:15:36Z",
+    "sha": "90625b8ea681669ff21ad8aca36d6a221f7c9350",
+    "date": "2025-10-29T00:48:44Z",
     "author": "CI Bot <ci@trendmarketv2.local>",
     "rationale": "auto-sync action pins for workflow consistency"
   },
@@ -11,7 +11,7 @@
       "repo": "actions/checkout",
       "ref": "11bd71901bbe5b1630ceea73d27597364c9af683",
       "sha": "11bd71901bbe5b1630ceea73d27597364c9af683",
-      "date": "2025-10-27T18:30:28Z",
+      "date": "2025-10-29T00:48:44Z",
       "author": "CI Bot <ci@trendmarketv2.local>",
       "rationale": "auto-sync action pins for workflow consistency",
       "url": "https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683"
@@ -20,7 +20,7 @@
       "repo": "actions/download-artifact",
       "ref": "d3f86a106a0bac45b974a628896c90dbdf5c8093",
       "sha": "d3f86a106a0bac45b974a628896c90dbdf5c8093",
-      "date": "2025-10-27T18:30:28Z",
+      "date": "2025-10-29T00:48:44Z",
       "author": "CI Bot <ci@trendmarketv2.local>",
       "rationale": "auto-sync action pins for workflow consistency",
       "url": "https://github.com/actions/download-artifact/commit/d3f86a106a0bac45b974a628896c90dbdf5c8093"
@@ -29,16 +29,7 @@
       "repo": "actions/setup-python",
       "ref": "42375524e23c412d93fb67b49958b491fce71c38",
       "sha": "42375524e23c412d93fb67b49958b491fce71c38",
-      "date": "2025-10-27T18:30:28Z",
-      "author": "CI Bot <ci@trendmarketv2.local>",
-      "rationale": "auto-sync action pins for workflow consistency",
-      "url": "https://github.com/actions/setup-python/commit/42375524e23c412d93fb67b49958b491fce71c38"
-    },
-    {
-      "repo": "actions/setup-python",
-      "ref": "v5",
-      "sha": "42375524e23c412d93fb67b49958b491fce71c38",
-      "date": "2025-10-27T18:30:28Z",
+      "date": "2025-10-29T00:48:44Z",
       "author": "CI Bot <ci@trendmarketv2.local>",
       "rationale": "auto-sync action pins for workflow consistency",
       "url": "https://github.com/actions/setup-python/commit/42375524e23c412d93fb67b49958b491fce71c38"
@@ -47,37 +38,19 @@
       "repo": "actions/upload-artifact",
       "ref": "ea165f8d65b6e75b540449e92b4886f43607fa02",
       "sha": "ea165f8d65b6e75b540449e92b4886f43607fa02",
-      "date": "2025-10-27T18:30:28Z",
+      "date": "2025-10-29T00:48:44Z",
       "author": "CI Bot <ci@trendmarketv2.local>",
       "rationale": "auto-sync action pins for workflow consistency",
       "url": "https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02"
     },
     {
       "repo": "docker/login-action",
-      "ref": "f4ef339be1f7c0066db2ed1d1c637d705d7d76e8",
-      "sha": "f4ef339be1f7c0066db2ed1d1c637d705d7d76e8",
-      "date": "2025-10-27T18:30:28Z",
+      "ref": "e995cd7a8f6f9b877a4c1a27820f3e397985f9f2",
+      "sha": "e995cd7a8f6f9b877a4c1a27820f3e397985f9f2",
+      "date": "2025-10-29T00:48:44Z",
       "author": "CI Bot <ci@trendmarketv2.local>",
       "rationale": "auto-sync action pins for workflow consistency",
-      "url": "https://github.com/docker/login-action/commit/f4ef339be1f7c0066db2ed1d1c637d705d7d76e8"
-    },
-    {
-      "repo": "returntocorp/semgrep-action",
-      "ref": "d2118d8864c8ad5ac2ffb5f062e30aea0a43d0f0",
-      "sha": "d2118d8864c8ad5ac2ffb5f062e30aea0a43d0f0",
-      "date": "2025-10-27T18:30:28Z",
-      "author": "CI Bot <ci@trendmarketv2.local>",
-      "rationale": "auto-sync action pins for workflow consistency",
-      "url": "https://github.com/returntocorp/semgrep-action/commit/d2118d8864c8ad5ac2ffb5f062e30aea0a43d0f0"
-    },
-    {
-      "repo": "returntocorp/semgrep-action",
-      "ref": "v1",
-      "sha": "d2118d8864c8ad5ac2ffb5f062e30aea0a43d0f0",
-      "date": "2025-10-27T18:30:28Z",
-      "author": "CI Bot <ci@trendmarketv2.local>",
-      "rationale": "auto-sync action pins for workflow consistency",
-      "url": "https://github.com/returntocorp/semgrep-action/commit/d2118d8864c8ad5ac2ffb5f062e30aea0a43d0f0"
+      "url": "https://github.com/docker/login-action/commit/e995cd7a8f6f9b877a4c1a27820f3e397985f9f2"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- ensure the Sprint 1 guard always emits structured summaries and stage bundles, with updated tests covering the new artifacts
- align Boss Final aggregation with the schema const and surface the expected vs. current identifier in the workflow for easier troubleshooting
- modernize the actions pin tooling and regenerate `actions.lock`, and migrate the Semgrep workflow to a pinned CLI-based execution

## Testing
- `pytest tests/boss_final -q`
- `ruff check scripts/boss_final tests/boss_final .github/scripts`


------
https://chatgpt.com/codex/tasks/task_e_69016170a0a0833091dd5180c7eca190