### PR TITLE
fix(ci): pin artifact actions by commit; unblock Q1 Final Boss

### DIFF
--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Download stage artifacts
         if: always()
-        uses: actions/download-artifact@cc20338ba2f079446182a90c0d65f173b7af4b23  # pinned (was v4)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # pinned (v5)
         with:
           pattern: boss-stage-*
           merge-multiple: true


### PR DESCRIPTION
## Summary
- update the Q1 Final Boss workflow to pin actions/download-artifact to commit 634f93c

## Testing
- not run (workflow dispatch requires GitHub environment)

------
https://chatgpt.com/codex/tasks/task_e_69018237c4248330bfd48f68918ff07d