### PR TITLE
Normalize GitHub Actions uses pins and fix boss final scripts

### DIFF
--- a/.github/scripts/normalize_uses_pins.py
+++ b/.github/scripts/normalize_uses_pins.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+ROOTS = [Path('.github/workflows')]
+PAT = re.compile(r"^(\s*(?:-\s*)?uses\s*:\s*[\w.-]+/[\w.-]+@[0-9a-fA-F]{40,})(\s+#.*)?\s*$")
+
+def normalize_file(path: Path) -> bool:
+    lines = path.read_text(encoding='utf-8', errors='ignore').splitlines()
+    changed = False
+    output_lines = []
+    for line in lines:
+        match = PAT.match(line)
+        if match:
+            output_lines.append(match.group(1))
+            changed = True
+        else:
+            output_lines.append(line)
+    if changed:
+        path.write_text('\n'.join(output_lines) + '\n', encoding='utf-8')
+    return changed
+
+def main() -> None:
+    any_changed = False
+    for root in ROOTS:
+        for file in root.rglob('*.y*ml'):
+            any_changed |= normalize_file(file)
+    print('[normalize-uses] changed' if any_changed else '[normalize-uses] clean')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/_crd-orr.yml
+++ b/.github/workflows/_crd-orr.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
 
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload ORR bundle
 
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: obs-bundle-${{ inputs.profile }}-${{ inputs.environment }}
           path: |

--- a/.github/workflows/_mbp-s2-orr.yml
+++ b/.github/workflows/_mbp-s2-orr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Tooling versions
         shell: bash
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Publicar artefatos
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: orr-evidence
           path: out/orr_gatecheck/evidence

--- a/.github/workflows/_mbp-s3-orr.yml
+++ b/.github/workflows/_mbp-s3-orr.yml
@@ -7,7 +7,7 @@ jobs:
   orr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Tooling versions
         run: |
           bash --version | head -n1 || true
@@ -36,7 +36,7 @@ jobs:
             echo "FREEZE=NO — ok para prosseguir"
           fi
       - name: Publicar artefatos
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: s3-evidence
           path: out/s3_gatecheck/evidence

--- a/.github/workflows/_run-s3-command.yml
+++ b/.github/workflows/_run-s3-command.yml
@@ -10,7 +10,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: sudo apt-get update && sudo apt-get install -y python3 jq
       - run: |
           set -euo pipefail
@@ -19,7 +19,7 @@ jobs:
           eval ${{ github.event.inputs.cmd }} | tee /tmp/cmd.out
           echo "---"
           echo "Conteúdo de out/s3_gatecheck:"; ls -la out/s3_gatecheck || true
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: s3-run-output
           path: |

--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ inputs.ref || github.sha }}
 
@@ -199,7 +199,7 @@ jobs:
 
       - name: Security | Upload findings
         if: ${{ always() && inputs.run_security }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: security-findings
           path: out/security/**
@@ -263,7 +263,7 @@ jobs:
 
       - name: GHCR login (opcional)
         if: ${{ inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' && steps.ghcr_tok.outputs.has_token == 'true' }}
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # pinned (was v3)
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -347,7 +347,7 @@ jobs:
           exit "$RC"
 
       - name: Upload TLA report
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         if: ${{ always() && inputs.run_tla && steps.tla_scan.outputs.have_tla == 'true' }}
         with:
           name: tla-report
@@ -483,7 +483,7 @@ jobs:
 
       - name: Upload dbt docs
         if: ${{ always() }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: s4-dbt-docs
           path: analytics/dbt/target
@@ -491,7 +491,7 @@ jobs:
 
       - name: Upload bundle
         if: ${{ always() && !inputs.run_tla }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: s5-bundle
           path: |
@@ -504,7 +504,7 @@ jobs:
 
       - name: Upload auditoria pip
         if: ${{ always() && !inputs.run_tla }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: pip-audit
           path: out/pip-audit
@@ -512,7 +512,7 @@ jobs:
 
       - name: Upload s5-orr evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: s5-orr-evidence
           path: |

--- a/.github/workflows/canary-sampler.yml
+++ b/.github/workflows/canary-sampler.yml
@@ -4,7 +4,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Sample 100 users
         shell: bash
         run: |

--- a/.github/workflows/crd-epic-plan.yml
+++ b/.github/workflows/crd-epic-plan.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Resolver inputs (IssueOps)
         id: io
@@ -97,7 +97,7 @@ jobs:
           echo "PLAN_OK"
 
       - name: Publicar artefatos (plan)
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: crd-epic-plan-${{ github.ref_name }}-${{ github.run_id }}
           path: ${{ steps.io.outputs.out_dir }}/

--- a/.github/workflows/q1-boss-final.yml
+++ b/.github/workflows/q1-boss-final.yml
@@ -63,8 +63,8 @@ jobs:
             exit 2
           fi
       - name: "Checkout"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # pinned (was v5)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: "3.11"
           check-latest: true
@@ -95,6 +95,12 @@ jobs:
           echo "STAGE_ARTIFACT_DIR=$ART_DIR" >> "$GITHUB_ENV"
           echo "ARTIFACT_DIR=$ART_DIR" >> "$GITHUB_ENV"
 
+      - name: Normalize uses pins (strip comments)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python .github/scripts/normalize_uses_pins.py
+
       - name: "Execute sprint guard"
         timeout-minutes: 5
         run: bash scripts/boss_final/ci_stage_wrapper.sh
@@ -123,7 +129,7 @@ jobs:
           ls -lh "$zip_path"
       - name: "Upload stage artifact (zip)"
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: boss-stage-${{ env.STAGE }}
           path: out/boss/boss-stage-${{ env.STAGE }}.zip
@@ -151,7 +157,7 @@ jobs:
             exit 2
           fi
       - name: "Checkout"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: "Setup Python + venv + deps"
         uses: ./.github/actions/setup-python-venv
 
@@ -164,7 +170,7 @@ jobs:
 
       - name: "Download stage artifacts"
         if: always()
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # pinned (v5)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           pattern: boss-stage-*
           merge-multiple: true
@@ -271,7 +277,7 @@ jobs:
 
       - name: "Upload Boss Final aggregate"
         if: steps.aggregate.outcome == 'success'
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: boss-final-aggregate
           path: |

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload guard report
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: repo-guard-report
           path: out/repo_guard/**/*.txt

--- a/.github/workflows/s4-exec.yml
+++ b/.github/workflows/s4-exec.yml
@@ -59,7 +59,7 @@ jobs:
     needs: [call-orr]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Preparar zips de estágio → out/boss
         shell: bash

--- a/.github/workflows/s5-validation.yml
+++ b/.github/workflows/s5-validation.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ inputs.ref || github.sha }}
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Sprint 5 artifacts
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: sprint5-validation-artifacts
           path: |

--- a/.github/workflows/s6-scorecards.yml
+++ b/.github/workflows/s6-scorecards.yml
@@ -45,7 +45,7 @@ jobs:
       CLEAN_RUNNER: ${{ matrix.clean_runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install Python 3.11
         run: |
@@ -208,7 +208,7 @@ jobs:
         run: python scripts/scorecards/s6_scorecards.py
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: s6-scorecards
           path: ${{ env.REPORT_DIR }}

--- a/.github/workflows/sanity-actions.yml
+++ b/.github/workflows/sanity-actions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Sanity — no tag-based actions
         run: bash scripts/ci/check_no_tags_left.sh
       - name: Verify action pins and existence
@@ -23,7 +23,7 @@ jobs:
           python .github/scripts/verify_pins.py --report out/guard/s4/actions_pins_report.json
       - name: Upload pins report
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: sanity-actions-pins
           path: out/guard/s4/actions_pins_report.json

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # pinned (was v5)
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: "3.11"
           check-latest: true
@@ -36,7 +36,7 @@ jobs:
           fi
       - name: Upload Semgrep results
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # pinned (was v4)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: semgrep-sarif
           path: out/guard/s4/semgrep.sarif

--- a/.github/workflows/shadow-toggle.yml
+++ b/.github/workflows/shadow-toggle.yml
@@ -19,7 +19,7 @@ jobs:
   toggle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # pinned (was v4)
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Atualizar configs/shadow.env
         run: |
           mkdir -p configs

--- a/scripts/boss_final/enforce_report_defaults.py
+++ b/scripts/boss_final/enforce_report_defaults.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-import json, sys
+import json
+import sys
 from pathlib import Path
 
 CANDIDATES = [


### PR DESCRIPTION
## Summary
- separate the Ruff-triggering combined import in `scripts/boss_final/enforce_report_defaults.py`
- add a reusable script that strips inline comments after `uses: …@<SHA>` and call it from the Q1 Boss Final workflow
- normalize existing workflows so all pinned `uses:` entries are bare SHA references

## Testing
- rg -n "uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@v[0-9]" .github/workflows
- rg -n "uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[0-9a-fA-F]{40,}\s+#" .github/workflows
- yamllint -s .github/workflows *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_690195ee9f0c83308c5d47184a4dd850