### PR TITLE
Fix reusable ORR workflow secret declaration

### DIFF
--- a/.github/workflows/_s4-orr.yml
+++ b/.github/workflows/_s4-orr.yml
@@ -48,8 +48,6 @@ on:
         type: boolean
         default: false
     secrets:
-      GITHUB_TOKEN:
-        required: false
       GCP_SA_JSON:
         required: false
       DBT_BQ_PROJECT:


### PR DESCRIPTION
## Summary
- remove the `GITHUB_TOKEN` secret declaration from the `_s4-orr` reusable workflow to satisfy workflow_call restrictions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902ba896010833080bfeadd655cdd3e