### PR TITLE
Fix Semgrep reusable workflow syntax

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -23,11 +23,6 @@ on:
 
 permissions:
   contents: read
-    secrets:
-      SEMGREP_APP_TOKEN:
-        required: false
-
-
 
 jobs:
   semgrep:
@@ -36,10 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref != '' && inputs.ref || github.sha }}
-          ref: ${{ github.event_name == 'workflow_call' && (inputs.ref != '' && inputs.ref || github.sha) || github.sha }}
           # Se chamado via `uses:`, honrar o ref recebido; senão usar o commit atual
-          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
+          ref: ${{ github.event_name == 'workflow_call' && inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38


### PR DESCRIPTION
## Summary
- fix indentation for permissions block in Semgrep workflow
- remove duplicated checkout ref lines to restore valid yaml

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902bbe2d2808330a9bf7abc3777bc16