### PR TITLE
Fix actionlint download in S7 validation workflow

### DIFF
--- a/.github/workflows/validate-s7.yml
+++ b/.github/workflows/validate-s7.yml
@@ -44,7 +44,17 @@ jobs:
       - name: Actionlint
         run: |
           set -euo pipefail
-          curl -sSfL "https://github.com/rhysd/actionlint/releases/latest/download/actionlint_$(uname -s)_$(uname -m).tar.gz" \
+          case "$(uname -s)" in
+            Linux) os="linux" ;;
+            Darwin) os="darwin" ;;
+            *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64) arch="amd64" ;;
+            arm64|aarch64) arch="arm64" ;;
+            *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL "https://github.com/rhysd/actionlint/releases/latest/download/actionlint_${os}_${arch}.tar.gz" \
             | tar -xz actionlint
           ./actionlint -color
           pip install ruff pytest pynacl cryptography psutil


### PR DESCRIPTION
## Summary
- update the validate-s7 workflow to translate uname output to the values expected by actionlint release assets
- download the platform-specific tarball using the normalized os and architecture names before running actionlint

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_6902befe0f088330a98605c00091683e