### PR TITLE
Hotfix S7: exportar sign_batch/verify_signature (APIs p/ testes) — zero colaterais

### DIFF
--- a/scripts/crypto/verify_signature.py
+++ b/scripts/crypto/verify_signature.py
@@ -1,17 +1,32 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-
-import base64
-import json
-import os
-import sys
+import os, sys, json, base64
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
+from nacl import signing, exceptions as nacl_exc
 
-from nacl import exceptions as nacl_exc
-from nacl import signing
-
+PathLike = Union[str, Path]
 KEY_ID = os.environ.get("ORACLE_SIGNING_KEY_ID", "s7-active-20251001")
+
+def _default_batch_dir() -> Path:
+    return Path("out/evidence/S7_event_model")
+
+def _choose_batch_json_and_sig(bj: Optional[PathLike] = None, bs: Optional[PathLike] = None) -> tuple[Path, Path]:
+    root = _default_batch_dir()
+    bj_path = Path(bj) if bj is not None else (root / "batch.json")
+    if not bj_path.exists():
+        candidates = sorted(root.glob("*.json"))
+        if not candidates:
+            raise FileNotFoundError("no batch JSON found to verify")
+        bj_path = candidates[-1]
+    bs_path = Path(bs) if bs is not None else (root / "batch.sig")
+    if not bs_path.exists():
+        cand = bj_path.with_suffix(".sig")
+        if cand.exists():
+            bs_path = cand
+        else:
+            raise FileNotFoundError("no signature file found for batch")
+    return bj_path, bs_path
 
 def _load_pub_from_pubmeta(dir_: Path) -> Optional[bytes]:
     p = dir_ / "pubkey.json"
@@ -23,71 +38,60 @@ def _load_pub_from_pubmeta(dir_: Path) -> Optional[bytes]:
         return None
     return base64.b64decode(b64, validate=True)
 
-def _choose_batch_files() -> tuple[Path, Path]:
-    root = Path("out/evidence/S7_event_model")
-    bj, bs = root / "batch.json", root / "batch.sig"
-    if not bj.exists():
-        # escolhe o mais novo
-        js = sorted(root.glob("*.json"))
-        if not js:
-            print("[verify] no batch JSON found to verify", file=sys.stderr)
-            sys.exit(1)
-        bj = js[-1]
-    if not bs.exists():
-        # tenta sig de mesmo stem
-        cand = bj.with_suffix(".sig")
-        if cand.exists():
-            bs = cand
-        else:
-            print("[verify] no signature file found for batch", file=sys.stderr)
-            sys.exit(1)
-    return bj, bs
-
-def _load_pub_from_env() -> Optional[bytes]:
+def _pub_from_env() -> Optional[bytes]:
     val = os.environ.get("ORACLE_ED25519_PUB")
     if not val:
         return None
     return base64.b64decode(val, validate=True)
 
-def _derive_pub_from_seed() -> Optional[bytes]:
+def _pub_from_seed() -> Optional[bytes]:
     seed_b64 = os.environ.get("ORACLE_ED25519_SEED")
     if not seed_b64:
         return None
     raw = base64.b64decode(seed_b64, validate=True)
     if len(raw) != 32:
-        print("[verify] ORACLE_ED25519_SEED is not 32 bytes after base64", file=sys.stderr)
-        sys.exit(1)
+        raise ValueError("ORACLE_ED25519_SEED is not 32 bytes after base64")
     return bytes(signing.SigningKey(raw).verify_key)
 
-def main() -> None:
-    bj, bs = _choose_batch_files()
-    pub: Optional[bytes] = None
+def verify_signature(
+    batch_json: Optional[PathLike] = None,
+    sig_path: Optional[PathLike] = None,
+    pubkey_b64: Optional[str] = None,
+) -> bool:
+    bj, bs = _choose_batch_json_and_sig(batch_json, sig_path)
 
-    # 1) pubkey.json canônico
-    pub = _load_pub_from_pubmeta(bj.parent)
-    # 2) env ORACLE_ED25519_PUB (base64)
+    pub: Optional[bytes] = None
+    if pubkey_b64:
+        pub = base64.b64decode(pubkey_b64, validate=True)
     if pub is None:
-        pub = _load_pub_from_env()
-    # 3) derivar da seed (fallback; requer secret no ambiente)
+        pub = _load_pub_from_pubmeta(bj.parent)
     if pub is None:
-        pub = _derive_pub_from_seed()
+        pub = _pub_from_env()
     if pub is None:
-        print(
-            "[verify] missing public key: provide pubkey.json, ORACLE_ED25519_PUB, or ORACLE_ED25519_SEED",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        pub = _pub_from_seed()
+    if pub is None:
+        raise RuntimeError("missing public key: provide pubkey.json, ORACLE_ED25519_PUB, or ORACLE_ED25519_SEED")
 
     vk = signing.VerifyKey(pub)
-    data = bj.read_bytes()
+    data = Path(bj).read_bytes()
     sig = Path(bs).read_bytes()
     try:
         vk.verify(data, sig)
     except nacl_exc.BadSignatureError:
+        return False
+    return True
+
+def main() -> None:
+    ok = False
+    try:
+        ok = verify_signature()
+    except Exception as e:  # noqa: BLE001
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+    if not ok:
         print("Signature verification failed", file=sys.stderr)
         sys.exit(1)
-
-    print(f"[verify] OK for {bj.name}")
+    print("[verify] OK")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- exporta `sign_batch` como função reutilizável mantendo comportamento CLI existente
- exporta `verify_signature` como função reutilizável mantendo os fallbacks atuais de chave pública

## Testing
- pytest -q tests/test_normalizer.py tests/test_signature.py *(falha: ModuleNotFoundError: No module named 'nacl')*

------
https://chatgpt.com/codex/tasks/task_e_6902da0cb51483309204d10d4e763d3d