### PR TITLE
Hotfix S7: split imports (Ruff E401) — zero colaterais

### DIFF
--- a/scripts/crypto/sign_batch.py
+++ b/scripts/crypto/sign_batch.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import os, sys, base64, json, re
+import base64
+import json
+import os
+import re
+import sys
 from pathlib import Path
-from typing import Optional, Union, Dict
+from typing import Dict, Optional, Union
 from nacl import signing
 
 PathLike = Union[str, Path]

--- a/scripts/crypto/verify_signature.py
+++ b/scripts/crypto/verify_signature.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import os, sys, json, base64
+import base64
+import json
+import os
+import sys
 from pathlib import Path
 from typing import Optional, Union
 from nacl import signing, exceptions as nacl_exc


### PR DESCRIPTION
## Summary
- split the combined imports in `scripts/crypto/sign_batch.py` to resolve Ruff E401
- split the combined imports in `scripts/crypto/verify_signature.py` to resolve Ruff E401

## Testing
- `ruff check scripts/crypto/sign_batch.py scripts/crypto/verify_signature.py`
- `pytest -q tests/test_normalizer.py tests/test_signature.py` *(fails: ModuleNotFoundError: No module named 'nacl')*
- `make validate-s7` *(fails: Makefile:11: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_6902dd1ff908833097693acd870f53d4