### PR TITLE
Make _s7-orr reusable workflow and update wrapper inputs

### DIFF
--- a/.github/workflows/_s7-orr.yml
+++ b/.github/workflows/_s7-orr.yml
@@ -1,6 +1,27 @@
 name: "S7 ORR Exec"
 on:
-  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+      run_microbench:
+        type: boolean
+        required: false
+        default: false
+      run_tla:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      GCP_SA_JSON:
+        required: false
+      DBT_BQ_PROJECT:
+        required: false
+      DBT_BQ_DATASET:
+        required: false
+      DBT_BQ_LOCATION:
+        required: false
 
 env:
   TZ: UTC
@@ -14,6 +35,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - name: Ruleset sanity
         run: python -m scripts.ci.ruleset_sanity --out out/evidence/T0_ruleset_sanity/ruleset_check.json
 
@@ -21,6 +44,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - name: Lint YAML
         run: |
           python -m scripts.ci.filemap_check --out out/evidence/T1_yaml/filemap_check.json
@@ -30,6 +55,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - name: Run gitleaks
         run: |
           mkdir -p out/evidence/T2_security
@@ -39,6 +66,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - name: Generate lock
         run: |
           python -m scripts.ci.generate_actions_lock > actions.lock
@@ -52,6 +81,8 @@ jobs:
         python-version: ["3.11.14", "3.11.9"]
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - uses: actions/setup-python@3fbe49a64b204ce5b05c73e4593934d6683f2f87  # pinned (was v5)
         with:
           python-version: ${{ matrix.python-version }}
@@ -64,6 +95,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - uses: actions/setup-python@3fbe49a64b204ce5b05c73e4593934d6683f2f87  # pinned (was v5)
         with:
           python-version: "3.11.14"
@@ -79,6 +112,8 @@ jobs:
         python-version: ["3.11.14", "3.11.9"]
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - uses: actions/setup-python@3fbe49a64b204ce5b05c73e4593934d6683f2f87  # pinned (was v5)
         with:
           python-version: ${{ matrix.python-version }}
@@ -91,6 +126,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - uses: actions/setup-python@3fbe49a64b204ce5b05c73e4593934d6683f2f87  # pinned (was v5)
         with:
           python-version: "3.11.14"
@@ -110,6 +147,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@f43a0e5d5da3b32b842f6cce0cf5b7a9766f2a72  # pinned (was v4)
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - uses: actions/setup-python@3fbe49a64b204ce5b05c73e4593934d6683f2f87  # pinned (was v5)
         with:
           python-version: "3.11.14"

--- a/.github/workflows/s7-exec.yml
+++ b/.github/workflows/s7-exec.yml
@@ -1,6 +1,18 @@
 name: "S7 ORR Exec Wrapper"
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        required: false
+      run_microbench:
+        type: boolean
+        required: false
+        default: false
+      run_tla:
+        type: boolean
+        required: false
+        default: false
   push:
     branches:
       - q2-s7-codex-**
@@ -8,3 +20,8 @@ on:
 jobs:
   run:
     uses: ./.github/workflows/_s7-orr.yml
+    with:
+      ref: ${{ github.event.inputs.ref || github.sha }}
+      run_microbench: ${{ fromJSON(github.event.inputs.run_microbench || 'false') }}
+      run_tla: ${{ fromJSON(github.event.inputs.run_tla || 'false') }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- declare `_s7-orr` as a reusable workflow with `workflow_call` inputs/secrets and reuse the ref input on checkout steps
- expose matching `workflow_dispatch` inputs in `s7-exec` and forward typed values with `secrets: inherit`
- confirmed existing action pins remain aligned with `actions.lock`

## Testing
- ⚠️ `yamllint .github/workflows/s7-exec.yml .github/workflows/_s7-orr.yml` *(yamllint is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6907910995b08330b7ad541ad1132b81