### PR TITLE
Harden S7 ORR workflows

### DIFF
--- a/.github/workflows/_s7-orr.yml
+++ b/.github/workflows/_s7-orr.yml
@@ -37,47 +37,95 @@ jobs:
       status: ${{ steps.manifest.outputs.status }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Gate T0 — existence
+        with:
+          fetch-depth: 0
+      - name: Gate T0 — manifest integrity
         id: manifest
         run: |
           set -euo pipefail
           MAN="docs/DNA/Roadmap e Sprints/Q2/Sprint 7/s_7_filemap_v_7.json"
           OUT="out/obs_gatecheck/T0_discovery.json"
           mkdir -p "$(dirname "$OUT")"
-          status="PASS"
-          checked=0
-          missing=()
-          if [ ! -s "$MAN" ]; then
-            status="FAIL"
-            printf '{"gate":"T0","status":"FAIL","checked":0,"missing":["s_7_filemap_v_7.json"]}' > "$OUT"
-          else
-            while IFS= read -r line; do
-              path=$(printf '%s\n' "$line" | sed -n 's/.*"path"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p')
-              if [ -z "$path" ]; then
+          status=$(python - <<'PY'
+import json
+import subprocess
+from pathlib import Path
+
+man = Path("docs/DNA/Roadmap e Sprints/Q2/Sprint 7/s_7_filemap_v_7.json")
+out = Path("out/obs_gatecheck/T0_discovery.json")
+out.parent.mkdir(parents=True, exist_ok=True)
+
+result = {
+    "gate": "T0",
+    "status": "FAIL",
+    "checked": 0,
+    "missing": [],
+    "badhash": [],
+    "manifest": str(man),
+}
+
+if not man.exists() or man.stat().st_size == 0:
+    result["missing"].append(str(man))
+else:
+    jq_proc = subprocess.run([
+        "jq",
+        "-c",
+        ".",
+        str(man),
+    ], capture_output=True, text=True)
+    if jq_proc.returncode != 0:
+        result["badhash"].append({
+            "path": str(man),
+            "error": jq_proc.stderr.strip() or "jq_parse_error",
+        })
+    else:
+        for raw_line in jq_proc.stdout.splitlines():
+            if not raw_line.strip():
                 continue
-              fi
-              checked=$((checked + 1))
-              if [ ! -f "$path" ]; then
-                missing+=("$path")
-              fi
-            done < "$MAN"
-            if [ "${#missing[@]}" -gt 0 ]; then
-              status="FAIL"
-            fi
-            {
-              printf '{"gate":"T0","status":"%s","checked":%s,"missing":[' "$status" "$checked"
-              if [ "${#missing[@]}" -gt 0 ]; then
-                for i in "${!missing[@]}"; do
-                  printf '"%s"' "${missing[$i]}"
-                  if [ "$i" -lt $((${#missing[@]} - 1)) ]; then
-                    printf ','
-                  fi
-                done
-              fi
-              printf ']}'
-            } > "$OUT"
-          fi
-          echo "status=$status" >> "$GITHUB_OUTPUT"
+            try:
+                entry = json.loads(raw_line)
+            except json.JSONDecodeError as exc:
+                result["badhash"].append({
+                    "path": raw_line,
+                    "error": f"json:{exc.msg}",
+                })
+                continue
+            path_value = entry.get("path")
+            expected_sha = (entry.get("sha1") or "").strip()
+            if not path_value:
+                continue
+            path = Path(path_value)
+            result["checked"] += 1
+            if not path.is_file():
+                result["missing"].append(str(path))
+                continue
+            hash_proc = subprocess.run(
+                ["git", "hash-object", "--", str(path)],
+                capture_output=True,
+                text=True,
+            )
+            if hash_proc.returncode != 0:
+                result["badhash"].append({
+                    "path": str(path),
+                    "error": hash_proc.stderr.strip() or "hash_object_failed",
+                })
+                continue
+            actual_sha = hash_proc.stdout.strip()
+            if expected_sha and actual_sha and expected_sha.lower() != actual_sha.lower():
+                result["badhash"].append({
+                    "path": str(path),
+                    "expected": expected_sha,
+                    "actual": actual_sha,
+                })
+
+if not result["missing"] and not result["badhash"]:
+    result["status"] = "PASS"
+
+out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+print(result["status"])
+PY
+)
+          printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
       - name: Upload T0 evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -95,9 +143,11 @@ jobs:
     needs: t0_spec
     runs-on: ubuntu-22.04
     outputs:
-      status: ${{ steps.yamllint.outputs.status }}
+      status: ${{ steps.yamllint_post.outputs.status }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: '3.11'
@@ -105,30 +155,127 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install yamllint==1.35.1
-      - name: yamllint
-        id: yamllint
+          python -m pip install yamllint==1.35.1 ruamel.yaml==0.18.6
+      - name: yamllint (initial)
+        id: yamllint_initial
+        run: |
+          set -euo pipefail
+          mkdir -p out/evidence/T1_yaml
+          printf '{"attempts": []}\n' > out/evidence/T1_yaml/autofix_report.json
+          printf 'no changes\n' > out/evidence/T1_yaml/autofix.diff
+          : > out/evidence/T1_yaml/autofix_git_status.txt
+          set +e
+          yamllint -f parsable . | tee out/evidence/T1_yaml/yamllint.txt
+          rc=${PIPESTATUS[0]}
+          set -e
+          printf '%s\n' "$rc" > out/evidence/T1_yaml/exit_code_initial.txt
+          printf 'initial_rc=%s\n' "$rc" >> "$GITHUB_OUTPUT"
+      - name: Apply YAML autofix for simple issues
+        if: steps.yamllint_initial.outputs.initial_rc != '0'
+        id: yamllint_autofix
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+import json
+import re
+from pathlib import Path
+
+LOG_PATH = Path('out/evidence/T1_yaml/yamllint.txt')
+REPORT_PATH = Path('out/evidence/T1_yaml/autofix_report.json')
+
+simple_rules = {
+    'indentation',
+    'trailing-spaces',
+    'trailing-space',
+    'new-line-at-end-of-file',
+    'new-lines',
+    'document-start',
+    'empty-lines',
+    'braces',
+}
+
+targets = {}
+pattern = re.compile(r'^(?P<path>[^:]+):\d+:\d+:\s+(?P<level>\w+):.*\((?P<rule>[^)]+)\)')
+for line in LOG_PATH.read_text(encoding='utf-8', errors='ignore').splitlines():
+    match = pattern.match(line)
+    if not match:
+        continue
+    rule = match.group('rule')
+    if rule not in simple_rules:
+        continue
+    path = Path(match.group('path'))
+    targets.setdefault(path, set()).add(rule)
+
+from ruamel.yaml import YAML
+
+yaml = YAML()
+yaml.preserve_quotes = True
+yaml.width = 4096
+yaml.indent(mapping=2, sequence=4, offset=2)
+
+results = []
+for path, rules in targets.items():
+    entry = {"path": str(path), "rules": sorted(rules), "status": "skipped"}
+    try:
+        text = path.read_text(encoding='utf-8')
+    except FileNotFoundError:
+        entry["status"] = "missing"
+        results.append(entry)
+        continue
+    try:
+        data = yaml.load(text)
+    except Exception as exc:  # noqa: BLE001
+        entry["status"] = "error"
+        entry["error"] = f"load:{exc}"
+        results.append(entry)
+        continue
+    if data is None:
+        entry["status"] = "empty"
+        results.append(entry)
+        continue
+    try:
+        with path.open('w', encoding='utf-8') as handle:
+            yaml.dump(data, handle)
+        entry["status"] = "formatted"
+    except Exception as exc:  # noqa: BLE001
+        entry["status"] = "error"
+        entry["error"] = f"dump:{exc}"
+    results.append(entry)
+
+REPORT_PATH.write_text(json.dumps({"attempts": results}, indent=2), encoding='utf-8')
+PY
+          git status --short > out/evidence/T1_yaml/autofix_git_status.txt || true
+          git diff > out/evidence/T1_yaml/autofix.diff || true
+          if [ ! -s out/evidence/T1_yaml/autofix.diff ]; then
+            printf 'no changes\n' > out/evidence/T1_yaml/autofix.diff
+          fi
+      - name: yamllint (post-fix)
+        id: yamllint_post
         run: |
           set -euo pipefail
           mkdir -p out/evidence/T1_yaml
           set +e
-          yamllint -s . | tee out/evidence/T1_yaml/yamllint.txt
+          yamllint -f parsable . | tee out/evidence/T1_yaml/yamllint_post.txt
           rc=${PIPESTATUS[0]}
           set -e
+          printf '%s\n' "$rc" > out/evidence/T1_yaml/exit_code_post.txt
           if [ "$rc" -eq 0 ]; then
             status="PASS"
+            allow_manual_fix="true"
           else
             status="FAIL"
+            allow_manual_fix="false"
           fi
-          printf '%s\n' "$rc" > out/evidence/T1_yaml/exit_code.txt
-          echo "status=$status" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$status" > out/evidence/T1_yaml/status.txt
+          printf '%s\n' "$allow_manual_fix" > out/evidence/T1_yaml/ALLOW_MANUAL_FIX.txt
+          printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
       - if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: s7-t1-yaml
           path: out/evidence/T1_yaml
       - name: Fail on YAML issues
-        if: steps.yamllint.outputs.status == 'FAIL'
+        if: steps.yamllint_post.outputs.status == 'FAIL'
         run: |
           echo "::error::YAML validation failed. See s7-t1-yaml artifact for details."
           exit 1
@@ -141,6 +288,8 @@ jobs:
       status: ${{ steps.gitleaks.outputs.status }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - name: Install gitleaks
         run: |
           set -euo pipefail
@@ -167,6 +316,47 @@ jobs:
             status="FAIL"
           fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
+      - name: Summarise gitleaks findings
+        if: always()
+        run: |
+          set -euo pipefail
+          report="out/evidence/T2_security/gitleaks_report.json"
+          mkdir -p "$(dirname "$report")"
+          if [ ! -s "$report" ]; then
+            printf '{"findings": []}\n' > "$report"
+          fi
+          python - <<'PY'
+import json
+from pathlib import Path
+
+report_path = Path('out/evidence/T2_security/gitleaks_report.json')
+summary_path = Path('out/evidence/T2_security/gitleaks_summary.json')
+
+try:
+    raw = json.loads(report_path.read_text(encoding='utf-8'))
+except json.JSONDecodeError:
+    raw = {"findings": []}
+
+findings = raw if isinstance(raw, list) else raw.get('findings', [])
+
+entries = []
+for finding in findings:
+    entries.append({
+        'description': finding.get('description'),
+        'file': finding.get('file'),
+        'start_line': finding.get('startLine'),
+        'end_line': finding.get('endLine'),
+        'secret': bool(finding.get('secret')),  # redacted already
+        'rule': finding.get('ruleID'),
+    })
+
+summary = {
+    'total_findings': len(entries),
+    'entries': entries,
+}
+
+summary_path.write_text(json.dumps(summary, indent=2), encoding='utf-8')
+PY
       - if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -180,12 +370,17 @@ jobs:
 
   t3_pins:
     name: t3_pins
-    needs: t0_spec
+    needs:
+      - t0_spec
+      - t1_yaml
+      - t2_security
     runs-on: ubuntu-22.04
     outputs:
       status: ${{ steps.scan.outputs.status }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - name: scan pins
         id: scan
         run: |
@@ -203,23 +398,42 @@ CANONICAL = {
     "actions/download-artifact": "d3f86a106a0bac45b974a628896c90dbdf5c8093",
     "actions/setup-python": "42375524e23c412d93fb67b49958b491fce71c38",
 }
+
 pattern = re.compile(r"uses:\s*"?([\w.-]+/[\w.-]+)@([A-Za-z0-9]+)")
 issues = []
+
+def is_sha(ref: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-fA-F]{40}", ref))
+
 for path in Path(".github/workflows").rglob("*.yml"):
     for idx, line in enumerate(path.read_text().splitlines(), start=1):
         match = pattern.search(line)
         if not match:
             continue
         action, ref = match.groups()
-        if action in CANONICAL and CANONICAL[action] != ref:
+        if action in CANONICAL:
+            if CANONICAL[action] != ref:
+                issues.append({
+                    "file": str(path),
+                    "line": idx,
+                    "action": action,
+                    "expected": CANONICAL[action],
+                    "found": ref,
+                    "reason": "non_canonical_sha",
+                })
+        elif action.startswith("actions/") and not is_sha(ref):
             issues.append({
                 "file": str(path),
                 "line": idx,
                 "action": action,
-                "expected": CANONICAL[action],
                 "found": ref,
+                "reason": "unpinned_github_action",
             })
-Path("out/evidence/T3_pins/pin_audit.json").write_text(json.dumps({"issues": issues}, indent=2), encoding="utf-8")
+
+out_dir = Path("out/evidence/T3_pins")
+out_dir.mkdir(parents=True, exist_ok=True)
+Path(out_dir / "canonical_map.json").write_text(json.dumps(CANONICAL, indent=2), encoding="utf-8")
+Path(out_dir / "pin_audit.json").write_text(json.dumps({"issues": issues}, indent=2), encoding="utf-8")
 PY
           python - <<'PY'
 import json
@@ -253,7 +467,10 @@ PY
 
   t4_tests:
     name: t4_tests (py${{ matrix.py }})
-    needs: t0_spec
+    needs:
+      - t0_spec
+      - t1_yaml
+      - t2_security
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -261,6 +478,8 @@ PY
         py: ["3.11.9", "3.11.14"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.py }}
@@ -277,6 +496,43 @@ PY
           pip_install_rc=0
           freeze_rc=0
           pytest_rc=0
+          export TZ="UTC"
+          export PYTHONHASHSEED="0"
+          export PYTHONIOENCODING="utf-8"
+          export PYTHONUNBUFFERED="1"
+          export MPLBACKEND="Agg"
+          export DETERMINISTIC_SEED="1337"
+          cat <<'PY' > sitecustomize.py
+import os
+import random
+
+SEED = int(os.environ.get("DETERMINISTIC_SEED", "1337"))
+random.seed(SEED)
+
+try:
+    import numpy  # noqa: F401
+except Exception:  # noqa: BLE001
+    numpy = None
+if numpy is not None:
+    try:
+        numpy.random.seed(SEED)
+    except Exception:  # noqa: BLE001
+        pass
+
+try:
+    import torch
+except Exception:  # noqa: BLE001
+    torch = None
+if torch is not None:
+    try:
+        torch.manual_seed(SEED)
+        if hasattr(torch, 'cuda'):
+            torch.cuda.manual_seed_all(SEED)
+    except Exception:  # noqa: BLE001
+        pass
+
+os.environ.setdefault("TZ", "UTC")
+PY
           if [ -d tests ]; then
             status="PASS"
             set +e
@@ -312,12 +568,17 @@ PY
 
   t5_props:
     name: t5_props
-    needs: t0_spec
+    needs:
+      - t0_spec
+      - t1_yaml
+      - t2_security
     runs-on: ubuntu-22.04
     outputs:
       status: ${{ steps.placeholder.outputs.status }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - name: Placeholder properties report
         id: placeholder
         run: |
@@ -333,7 +594,10 @@ PY
 
   t6_determinism:
     name: t6_determinism (py${{ matrix.py }})
-    needs: t0_spec
+    needs:
+      - t0_spec
+      - t1_yaml
+      - t2_security
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -341,6 +605,8 @@ PY
         py: ["3.11.9", "3.11.14"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.py }}
@@ -352,21 +618,110 @@ PY
           set -euo pipefail
           out_dir="out/evidence/T6_determinism/${PY_VERSION}"
           mkdir -p "$out_dir"
-          OUT_DIR=$out_dir python - <<'PY'
+          export OUT_DIR="$out_dir"
+          export TZ="UTC"
+          export PYTHONHASHSEED="0"
+          export PYTHONIOENCODING="utf-8"
+          export PYTHONUNBUFFERED="1"
+          export MPLBACKEND="Agg"
+          export DETERMINISTIC_SEED="1337"
+          cat <<'PY' > sitecustomize.py
+import os
+import random
+
+SEED = int(os.environ.get("DETERMINISTIC_SEED", "1337"))
+random.seed(SEED)
+
+try:
+    import numpy  # noqa: F401
+except Exception:  # noqa: BLE001
+    numpy = None
+if numpy is not None:
+    try:
+        numpy.random.seed(SEED)
+    except Exception:  # noqa: BLE001
+        pass
+
+try:
+    import torch
+except Exception:  # noqa: BLE001
+    torch = None
+if torch is not None:
+    try:
+        torch.manual_seed(SEED)
+        if hasattr(torch, 'cuda'):
+            torch.cuda.manual_seed_all(SEED)
+    except Exception:  # noqa: BLE001
+        pass
+
+os.environ.setdefault("TZ", "UTC")
+PY
+          status=$(python - <<'PY'
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 out_dir = Path(os.environ['OUT_DIR'])
-data = {
-    'determinism_check': 'TODO',
-    'python_version': os.environ['PY_VERSION'],
-    'note': 'Adicionar verificações determinísticas reais (sorted outputs, random.seed(1337)).',
+out_dir.mkdir(parents=True, exist_ok=True)
+seed = int(os.environ.get('DETERMINISTIC_SEED', '1337'))
+
+code = """
+import json
+import os
+import random
+
+SEED = int(os.environ.get('DETERMINISTIC_SEED', '1337'))
+random.seed(SEED)
+
+try:
+    import numpy as _np
+except Exception:
+    _np = None
+if _np is not None:
+    try:
+        _np.random.seed(SEED)
+    except Exception:
+        pass
+
+payload = {
+    'seed': SEED,
+    'series': [random.random() for _ in range(10)],
 }
-(out_dir / 'det_report.json').write_text(json.dumps(data, indent=2), encoding='utf-8')
+if _np is not None:
+    payload['matrix'] = _np.random.rand(3, 3).tolist()
+print(json.dumps(payload, separators=(',', ':')))
+"""
+
+def run_attempt() -> dict:
+    env = os.environ.copy()
+    env['DETERMINISTIC_SEED'] = str(seed)
+    completed = subprocess.run(
+        [sys.executable, '-c', code],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    return json.loads(completed.stdout)
+
+attempts = [run_attempt(), run_attempt()]
+status = 'PASS' if attempts[0] == attempts[1] else 'FAIL'
+
+report = {
+    'gate': 'T6',
+    'python_version': os.environ.get('PY_VERSION'),
+    'status': status,
+    'attempts': attempts,
+}
+
+(out_dir / 'det_report.json').write_text(json.dumps(report, indent=2), encoding='utf-8')
+(out_dir / 'status.txt').write_text(f"{status}\n", encoding='utf-8')
+print(status)
 PY
-          printf 'TODO\n' > "$out_dir/status.txt"
-          echo "status=TODO" >> "$GITHUB_OUTPUT"
+)
+          printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
       - if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -375,57 +730,177 @@ PY
 
   t7_append_only:
     name: t7_append_only
-    needs: t0_spec
+    needs:
+      - t0_spec
+      - t1_yaml
+      - t2_security
     runs-on: ubuntu-22.04
     outputs:
       status: ${{ steps.guard.outputs.status }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - name: append-only guard
         id: guard
         run: |
           set -euo pipefail
           mkdir -p out/evidence/T7_append_only
-          BASE_DIR="obs/guards/append_only/baseline"
-          REPORT="out/evidence/T7_append_only/report.txt"
-          mkdir -p "$BASE_DIR"
-          : > "$REPORT"
-          mapfile -t targets < <(git ls-files 'data/**/*.jsonl' 'data/**/*.ndjson' 2>/dev/null)
-          status="PASS"
-          if [ "${#targets[@]}" -eq 0 ]; then
-            status="SKIP"
-            echo "no append-only targets found" > "$REPORT"
-          else
-            for target in "${targets[@]}"; do
-              safe_name="${target//\//__}.baseline"
-              baseline="$BASE_DIR/$safe_name"
-              if [ ! -f "$baseline" ]; then
-                cp "$target" "$baseline"
-                echo "baseline generated for $target" >> "$REPORT"
-                status="FAIL"
-                continue
-              fi
-              tmp_diff=$(mktemp)
-              diff -U0 <(sed 's/[[:space:]]\+$//' "$baseline") <(sed 's/[[:space:]]\+$//' "$target") > "$tmp_diff" || true
-              if awk 'BEGIN{ok=0} /^-/ { if ($0 !~ /^---/) ok=1 } END{ exit ok == 0 ? 0 : 1 }' "$tmp_diff"; then
-                echo "ok: append-only preserved $target" >> "$REPORT"
-              else
-                echo "FAIL: non-append change detected in $target" >> "$REPORT"
-                status="FAIL"
-              fi
-              rm -f "$tmp_diff"
-            done
-            while IFS= read -r -d '' baseline_file; do
-              rel="${baseline_file#${BASE_DIR}/}"
-              target_path="${rel%.baseline}"
-              target_path="${target_path//__/\/}"
-              if [ ! -f "$target_path" ]; then
-                echo "FAIL: baseline has no matching target for $target_path" >> "$REPORT"
-                status="FAIL"
-              fi
-            done < <(find "$BASE_DIR" -type f -name '*.baseline' -print0)
-          fi
-          echo "status=$status" >> "$GITHUB_OUTPUT"
+          mkdir -p obs/guards/append_only/baseline
+          mkdir -p obs/guards/append_only_exceptions
+          status=$(python - <<'PY'
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+BASE_DIR = Path('obs/guards/append_only/baseline')
+LEDGER_DIR = Path('obs/guards/append_only_exceptions')
+REPORT_TXT = Path('out/evidence/T7_append_only/report.txt')
+REPORT_JSON = Path('out/evidence/T7_append_only/report.json')
+
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+LEDGER_DIR.mkdir(parents=True, exist_ok=True)
+
+def git_ls(patterns: list[str]) -> list[Path]:
+    cmd = ['git', 'ls-files', *patterns]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f'git ls-files failed: {result.stderr}')
+    return [Path(line) for line in result.stdout.splitlines() if line.strip()]
+
+targets = git_ls(['data/**/*.jsonl', 'data/**/*.ndjson'])
+
+ledger_entries: dict[str, list[dict[str, str]]] = {}
+for entry_path in sorted(LEDGER_DIR.glob('*.json')):
+    try:
+        payload = json.loads(entry_path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as exc:
+        ledger_entries.setdefault('__ledger_errors__', []).append({
+            'file': str(entry_path),
+            'error': f'json:{exc.msg}',
+        })
+        continue
+    items = payload if isinstance(payload, list) else [payload]
+    for item in items:
+        path = item.get('path')
+        sha1 = (item.get('sha1') or '').lower()
+        signature = item.get('signature')
+        if not path or not sha1 or not signature:
+            ledger_entries.setdefault('__ledger_errors__', []).append({
+                'file': str(entry_path),
+                'error': 'missing_fields',
+            })
+            continue
+        ledger_entries.setdefault(path, []).append({
+            'sha1': sha1,
+            'signature': signature,
+        })
+
+entries = []
+overall_status = 'PASS'
+
+def compute_sha(path: Path) -> str:
+    result = subprocess.run(
+        ['git', 'hash-object', '--', str(path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip().lower()
+
+def normalise_lines(path: Path) -> list[str]:
+    return [line.rstrip('\n').rstrip() for line in path.read_text(encoding='utf-8').splitlines()]
+
+if not targets:
+    overall_status = 'SKIP'
+    REPORT_TXT.write_text('no append-only targets found\n', encoding='utf-8')
+else:
+    lines = []
+    for target in targets:
+        safe_name = target.as_posix().replace('/', '__') + '.baseline'
+        baseline = BASE_DIR / safe_name
+        current_entry = {
+            'path': target.as_posix(),
+            'baseline': baseline.as_posix(),
+            'status': 'UNKNOWN',
+            'exception_used': None,
+        }
+        if not target.exists():
+            current_entry['status'] = 'MISSING'
+            overall_status = 'FAIL'
+            entries.append(current_entry)
+            lines.append(f"FAIL: missing target {target.as_posix()}")
+            continue
+        if not baseline.exists():
+            baseline.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(target, baseline)
+            current_entry['status'] = 'BASELINE_CREATED'
+            overall_status = 'FAIL'
+            entries.append(current_entry)
+            lines.append(f"FAIL: baseline generated for {target.as_posix()}")
+            continue
+        baseline_lines = normalise_lines(baseline)
+        target_lines = normalise_lines(target)
+        baseline_sha = compute_sha(baseline)
+        target_sha = compute_sha(target)
+        current_entry['baseline_sha1'] = baseline_sha
+        current_entry['current_sha1'] = target_sha
+        if len(target_lines) < len(baseline_lines) or target_lines[:len(baseline_lines)] != baseline_lines:
+            ledger = ledger_entries.get(target.as_posix(), [])
+            exception = next((item for item in ledger if item['sha1'] == target_sha), None)
+            if exception:
+                current_entry['status'] = 'EXCEPTION'
+                current_entry['exception_used'] = exception
+                lines.append(
+                    f"WARN: non-append change allowed for {target.as_posix()} via {exception['signature']}"
+                )
+            else:
+                current_entry['status'] = 'FAIL'
+                overall_status = 'FAIL'
+                lines.append(f"FAIL: non-append change detected in {target.as_posix()}")
+        else:
+            current_entry['status'] = 'PASS'
+            lines.append(f"OK: append-only preserved {target.as_posix()}")
+        entries.append(current_entry)
+
+    # detect stale baselines
+    for baseline_file in BASE_DIR.glob('*.baseline'):
+        rel = baseline_file.name[:-9].replace('__', '/')
+        if not Path(rel).exists():
+            overall_status = 'FAIL'
+            entries.append({
+                'path': rel,
+                'baseline': baseline_file.as_posix(),
+                'status': 'ORPHAN_BASELINE',
+                'exception_used': None,
+            })
+            lines.append(f"FAIL: baseline has no matching target for {rel}")
+
+    REPORT_TXT.write_text('\n'.join(lines) + ('\n' if lines else ''), encoding='utf-8')
+
+if ledger_entries.get('__ledger_errors__'):
+    overall_status = 'FAIL'
+    entries.extend({
+        'path': '__ledger__',
+        'baseline': '',
+        'status': 'LEDGER_ERROR',
+        'error': error,
+        'exception_used': None,
+    } for error in ledger_entries['__ledger_errors__'])
+
+summary = {
+    'gate': 'T7',
+    'status': overall_status,
+    'entries': entries,
+}
+
+REPORT_JSON.write_text(json.dumps(summary, indent=2), encoding='utf-8')
+print(overall_status)
+PY
+)
+          printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
       - if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/s7-exec.yml
+++ b/.github/workflows/s7-exec.yml
@@ -43,18 +43,21 @@ jobs:
         with:
           name: s7-t0-evidence
           path: s7-t0-evidence
+          if-no-files-found: warn
       - name: Summarise T0 discovery
         if: always()
         run: |
           set -euo pipefail
           if [[ ! -f s7-t0-evidence/T0_discovery.json ]]; then
-            echo "::warning::T0_discovery.json missing in wrapper run"
-            exit 0
+            mkdir -p s7-t0-evidence
+            cat <<'JSON' > s7-t0-evidence/T0_discovery.json
+{"gate":"T0","status":"MISSING","checked":0,"missing":[],"badhash":[]}
+JSON
           fi
           echo "T0_discovery.json contents:" >&2
           cat s7-t0-evidence/T0_discovery.json >&2
-          status=$(jq -r '.status' s7-t0-evidence/T0_discovery.json)
-          checked=$(jq -r '.checked' s7-t0-evidence/T0_discovery.json)
-          missing_count=$(jq '.missing | length' s7-t0-evidence/T0_discovery.json)
-          badhash_count=$(jq '.badhash | length' s7-t0-evidence/T0_discovery.json)
+          status=$(jq -r '.status // "UNKNOWN"' s7-t0-evidence/T0_discovery.json 2>/dev/null || echo "UNKNOWN")
+          checked=$(jq -r '.checked // 0' s7-t0-evidence/T0_discovery.json 2>/dev/null || echo 0)
+          missing_count=$(jq '.missing | length' s7-t0-evidence/T0_discovery.json 2>/dev/null || echo 0)
+          badhash_count=$(jq '.badhash | length' s7-t0-evidence/T0_discovery.json 2>/dev/null || echo 0)
           echo "::notice::T0 status=${status} checked=${checked} missing=${missing_count} badhash=${badhash_count}"

--- a/obs/guards/append_only_exceptions/.gitkeep
+++ b/obs/guards/append_only_exceptions/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for append-only exceptions ledger entries.
+# Each JSON file should contain objects with "path", "sha1" and "signature" keys.


### PR DESCRIPTION
## Summary
- harden the S7 callee by enforcing manifest hashing, prioritized gate ordering, canonical pin validation, and deterministic test/determinism jobs
- add resilient yamllint, gitleaks, append-only guard evidence generation with exception ledger support and canonical artifact stubs
- update the wrapper to tolerate missing evidence downloads while always emitting the T0 discovery notice and ship the append-only exception ledger scaffold

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_69090860c66c8330b2270d3c208db300